### PR TITLE
Add /setup-gemini and /setup-firecrawl slash commands

### DIFF
--- a/.claude/commands/setup-firecrawl.md
+++ b/.claude/commands/setup-firecrawl.md
@@ -2,16 +2,20 @@
 name: setup-firecrawl
 description: Interactive setup wizard for Firecrawl web scraping scripts
 allowed-tools: [Read, Write, Bash, AskUserQuestion]
-argument-hint: "(optional) skip steps with 'quick' if you already have API key configured"
+argument-hint:
+  "(optional) skip steps with 'quick' if you already have API key configured"
 ---
 
 # Firecrawl Setup Wizard
 
-This command guides you through setting up Firecrawl for web scraping, enabling you to save articles, documentation, and web content directly to your vault as clean, searchable markdown.
+This command guides you through setting up Firecrawl for web scraping, enabling
+you to save articles, documentation, and web content directly to your vault as
+clean, searchable markdown.
 
 ## Task
 
 Set up Firecrawl web scraping by:
+
 1. Explaining the benefits of Firecrawl for research workflows
 2. Getting a Firecrawl API key (300 free credits to start)
 3. Configuring the FIRECRAWL_API_KEY environment variable
@@ -25,8 +29,9 @@ Set up Firecrawl web scraping by:
 
 Start by explaining what Firecrawl enables:
 
-**The Research Game-Changer:**
-Instead of Claude reading webpages and summarizing (losing details), Firecrawl saves the FULL text as markdown in your vault. This means:
+**The Research Game-Changer:** Instead of Claude reading webpages and
+summarizing (losing details), Firecrawl saves the FULL text as markdown in your
+vault. This means:
 
 - **Permanent archive**: Articles stay in your vault forever
 - **Full context**: Complete text, not summaries
@@ -35,6 +40,7 @@ Instead of Claude reading webpages and summarizing (losing details), Firecrawl s
 - **Clean format**: Beautiful markdown, not messy HTML
 
 **Perfect for:**
+
 - Research projects (save all related articles)
 - Documentation archives (keep important guides)
 - Knowledge bases (build your own reference library)
@@ -44,12 +50,14 @@ Instead of Claude reading webpages and summarizing (losing details), Firecrawl s
 ### 2. Prerequisites Check
 
 Verify required tools are installed:
+
 ```bash
 curl --version  # Should be installed
 jq --version    # Should be installed (for JSON parsing)
 ```
 
 If jq is missing:
+
 - **macOS**: `brew install jq`
 - **Linux**: `apt-get install jq` or `yum install jq`
 - **Windows**: Use WSL or Git Bash
@@ -59,21 +67,25 @@ If jq is missing:
 Ask: "Do you already have a Firecrawl API key? (yes/no)"
 
 If no:
+
 1. Direct them to: https://firecrawl.dev
 2. Explain:
    - Sign up for free account
    - Get 300 free credits to start
    - Open-source project, can self-host if needed
-3. Guide to dashboard: "Go to your dashboard and copy your API key (starts with 'fc-...')"
+3. Guide to dashboard: "Go to your dashboard and copy your API key (starts with
+   'fc-...')"
 4. Wait for them to confirm they have the key
 
 If yes:
+
 1. Check if it's already in their environment: `echo $FIRECRAWL_API_KEY`
 2. If not set, ask them to provide it
 
 ### 4. Configure Environment Variable
 
 Detect their shell:
+
 ```bash
 echo $SHELL
 ```
@@ -81,18 +93,21 @@ echo $SHELL
 Based on the shell, add the API key to the appropriate config file:
 
 **For zsh** (.zshrc):
+
 ```bash
 echo 'export FIRECRAWL_API_KEY="fc-their-actual-key"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
 **For bash** (.bashrc or .bash_profile):
+
 ```bash
 echo 'export FIRECRAWL_API_KEY="fc-their-actual-key"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
 Verify it's set:
+
 ```bash
 echo $FIRECRAWL_API_KEY
 ```
@@ -102,6 +117,7 @@ echo $FIRECRAWL_API_KEY
 There are two scraping scripts in `.scripts/`:
 
 #### firecrawl-scrape.sh (Single URL)
+
 For scraping one URL at a time with control over the filename:
 
 ```bash
@@ -113,6 +129,7 @@ For scraping one URL at a time with control over the filename:
 ```
 
 #### firecrawl-batch.sh (Multiple URLs)
+
 For scraping multiple URLs at once with auto-generated filenames:
 
 ```bash
@@ -127,6 +144,7 @@ For scraping multiple URLs at once with auto-generated filenames:
 ### 6. Create Necessary Folders
 
 Make sure the default Clippings folder exists:
+
 ```bash
 mkdir -p 00_Inbox/Clippings
 ```
@@ -138,16 +156,19 @@ Perform a test scrape to verify everything works:
 Ask: "Would you like to test with a sample article? (yes/no)"
 
 If yes:
+
 ```bash
 .scripts/firecrawl-scrape.sh "https://example.com" "00_Inbox/test-scrape.md"
 ```
 
 Check the output:
+
 - Look for: "✓ Scraped content saved to: 00_Inbox/test-scrape.md"
 - Verify the file has content: `wc -l 00_Inbox/test-scrape.md`
 - Show first few lines: `head -20 00_Inbox/test-scrape.md`
 
 If successful, offer to delete test file:
+
 ```bash
 rm 00_Inbox/test-scrape.md
 ```
@@ -155,6 +176,7 @@ rm 00_Inbox/test-scrape.md
 ### 8. Show Research Workflows
 
 #### Workflow 1: Save Single Article
+
 ```bash
 # User says: "Save this article to my vault: https://blog.example.com/great-post"
 # You run:
@@ -162,6 +184,7 @@ rm 00_Inbox/test-scrape.md
 ```
 
 #### Workflow 2: Batch Research Collection
+
 ```bash
 # User provides list of research URLs
 # You run:
@@ -172,6 +195,7 @@ rm 00_Inbox/test-scrape.md
 ```
 
 #### Workflow 3: Build Reference Library
+
 ```bash
 # Save documentation and tutorials to Resources
 .scripts/firecrawl-batch.sh -o "03_Resources/Tech-Docs/" \
@@ -180,6 +204,7 @@ rm 00_Inbox/test-scrape.md
 ```
 
 #### Workflow 4: Reading List
+
 ```bash
 # Quickly save interesting articles to read later
 .scripts/firecrawl-batch.sh \
@@ -192,6 +217,7 @@ rm 00_Inbox/test-scrape.md
 ### 9. Usage Tips
 
 **Best Practices:**
+
 1. **Organize as you save**: Use meaningful filenames and folders
 2. **Batch similar content**: Group related articles in same folder
 3. **Add frontmatter**: After scraping, add tags/metadata to notes
@@ -199,12 +225,14 @@ rm 00_Inbox/test-scrape.md
 5. **Clean up**: Regularly process Clippings folder
 
 **Cost Management:**
+
 - Free tier: 300 credits
 - Each scrape uses ~1 credit
 - Monitor usage in Firecrawl dashboard
 - Can self-host for unlimited use
 
 **Common Patterns:**
+
 - Ask Claude: "Save this to my vault: [URL]"
 - Ask Claude: "Scrape these 10 articles into my Research folder: [URLs]"
 - Ask Claude: "Find and save the top 5 articles about [topic]"
@@ -212,6 +240,7 @@ rm 00_Inbox/test-scrape.md
 ### 10. Success Message
 
 Show a summary:
+
 ```
 ✓ Firecrawl is now set up!
 
@@ -256,6 +285,7 @@ For more web scraping options: https://docs.firecrawl.dev
 ## Output
 
 Progress through each step, showing:
+
 - ✓ Checkmarks for completed steps
 - Clear examples of usage
 - Verification that scraping works
@@ -269,6 +299,7 @@ Progress through each step, showing:
 ```
 
 Or with API key already configured:
+
 ```
 /setup-firecrawl quick
 ```

--- a/.claude/commands/setup-gemini.md
+++ b/.claude/commands/setup-gemini.md
@@ -1,17 +1,22 @@
 ---
 name: setup-gemini
-description: Interactive setup wizard for Gemini Vision MCP server for image/video analysis
+description:
+  Interactive setup wizard for Gemini Vision MCP server for image/video analysis
 allowed-tools: [Read, Write, Bash, AskUserQuestion]
-argument-hint: "(optional) skip steps with 'quick' if you already have API key configured"
+argument-hint:
+  "(optional) skip steps with 'quick' if you already have API key configured"
 ---
 
 # Gemini Vision Setup Wizard
 
-This command guides you through setting up the Gemini Vision MCP server, which enables Claude to analyze images, videos, PDFs, and other visual content in your vault.
+This command guides you through setting up the Gemini Vision MCP server, which
+enables Claude to analyze images, videos, PDFs, and other visual content in your
+vault.
 
 ## Task
 
 Set up Gemini Vision MCP server by:
+
 1. Checking prerequisites (Node.js v22+, pnpm, Claude Code)
 2. Getting a free Gemini API key from Google AI Studio
 3. Configuring the GEMINI_API_KEY environment variable
@@ -24,6 +29,7 @@ Set up Gemini Vision MCP server by:
 ### 1. Welcome & Prerequisites Check
 
 Start by welcoming the user and explaining what Gemini Vision does:
+
 - Analyze images directly (screenshots, diagrams, photos)
 - Extract text from PDFs and scanned documents
 - Process videos (local files and YouTube URLs)
@@ -31,6 +37,7 @@ Start by welcoming the user and explaining what Gemini Vision does:
 - Compare multiple images
 
 Then check prerequisites:
+
 ```bash
 node --version  # Should be v22+
 pnpm --version  # Should be installed
@@ -38,6 +45,7 @@ claude --version  # Should be installed
 ```
 
 If any are missing, guide them to install:
+
 - Node.js: https://nodejs.org/ (v22+)
 - pnpm: `npm install -g pnpm`
 - Claude Code: https://claude.ai/code
@@ -47,17 +55,20 @@ If any are missing, guide them to install:
 Ask: "Do you already have a Gemini API key configured? (yes/no)"
 
 If no:
+
 1. Direct them to: https://aistudio.google.com/apikey
 2. Explain: "Click 'Create API Key' and copy the key (starts with 'AIzaSy...')"
 3. Wait for them to confirm they have the key
 
 If yes:
+
 1. Check if it's already in their environment: `echo $GEMINI_API_KEY`
 2. If not set, ask them to provide it
 
 ### 3. Configure Environment Variable
 
 Detect their shell:
+
 ```bash
 echo $SHELL
 ```
@@ -65,18 +76,21 @@ echo $SHELL
 Based on the shell, add the API key to the appropriate config file:
 
 **For zsh** (.zshrc):
+
 ```bash
 echo 'export GEMINI_API_KEY="their-actual-api-key"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
 **For bash** (.bashrc or .bash_profile):
+
 ```bash
 echo 'export GEMINI_API_KEY="their-actual-api-key"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
 Verify it's set:
+
 ```bash
 echo $GEMINI_API_KEY
 ```
@@ -90,51 +104,62 @@ pnpm install
 ```
 
 This installs:
+
 - @google/generative-ai (Gemini API client)
 - @modelcontextprotocol/sdk (MCP server framework)
 - Other required dependencies
 
 If pnpm fails, fall back to npm:
+
 ```bash
 npm install
 ```
 
 ### 5. Register MCP Server
 
-Ask: "Do you want project-scoped (just this vault) or user-scoped (all projects) installation?"
+Ask: "Do you want project-scoped (just this vault) or user-scoped (all projects)
+installation?"
 
 **Project-scoped (recommended for this vault only)**:
+
 ```bash
 claude mcp add --scope project gemini-vision node .claude/mcp-servers/gemini-vision.mjs
 ```
 
-This will create .mcp.json. The MCP server will automatically inherit the GEMINI_API_KEY environment variable from your shell.
+This will create .mcp.json. The MCP server will automatically inherit the
+GEMINI_API_KEY environment variable from your shell.
 
 **User-scoped (all projects)**:
+
 ```bash
 claude mcp add --scope user gemini-vision node .claude/mcp-servers/gemini-vision.mjs
 ```
 
-This will update ~/.claude.json. The MCP server will automatically inherit the GEMINI_API_KEY environment variable from your shell.
+This will update ~/.claude.json. The MCP server will automatically inherit the
+GEMINI_API_KEY environment variable from your shell.
 
-**Important**: The API key is read from your shell environment (set in .zshrc/.bashrc), NOT stored in any config file. The MCP server inherits it automatically when Claude Code starts.
+**Important**: The API key is read from your shell environment (set in
+.zshrc/.bashrc), NOT stored in any config file. The MCP server inherits it
+automatically when Claude Code starts.
 
 ### 6. Test Connection
 
 Important: User must open a NEW Claude Code window for MCP to connect!
 
 Guide them to:
+
 1. Exit current Claude session (or open new terminal)
 2. Start Claude again: `claude`
 3. Check connection: `/mcp`
 4. Look for: `gemini-vision ✔ connected`
 
-If connected, test with a sample command:
-"Try: 'Use gemini-vision to list available tools'"
+If connected, test with a sample command: "Try: 'Use gemini-vision to list
+available tools'"
 
 ### 7. Success & Next Steps
 
 If everything works:
+
 - Congratulate them!
 - Show example commands:
   - "Analyze this image: 05_Attachments/screenshot.png"
@@ -143,7 +168,9 @@ If everything works:
   - "Suggest a filename for IMG_1234.jpg"
 
 If issues occur:
-- Direct them to troubleshooting guide: `.claude/mcp-servers/GEMINI_VISION_QUICK_START.md`
+
+- Direct them to troubleshooting guide:
+  `.claude/mcp-servers/GEMINI_VISION_QUICK_START.md`
 - Common issues:
   - Dependencies not installed → run `pnpm install`
   - Server not showing in /mcp → restart Claude Code
@@ -151,17 +178,21 @@ If issues occur:
 
 ## Troubleshooting Reference
 
-For detailed troubleshooting, refer to: `.claude/mcp-servers/GEMINI_VISION_QUICK_START.md`
+For detailed troubleshooting, refer to:
+`.claude/mcp-servers/GEMINI_VISION_QUICK_START.md`
 
 Common issues:
+
 1. "Cannot find package '@modelcontextprotocol/sdk'" → Run `pnpm install`
 2. Server shows "failed" → Check API key is set: `echo $GEMINI_API_KEY`
-3. Tools don't work → Verify API key is valid, restart terminal to reload env vars
+3. Tools don't work → Verify API key is valid, restart terminal to reload env
+   vars
 4. Server not listed in /mcp → Must restart Claude Code after adding server
 
 ## Output
 
 Progress through each step, showing:
+
 - ✓ Checkmarks for completed steps
 - Clear instructions for manual steps
 - Verification of each component
@@ -174,6 +205,7 @@ Progress through each step, showing:
 ```
 
 Or with API key already configured:
+
 ```
 /setup-gemini quick
 ```


### PR DESCRIPTION
## Summary

Adds two interactive setup wizard commands that were referenced in `/init-bootstrap` but were missing:

- `/setup-gemini` - Gemini Vision MCP server setup
- `/setup-firecrawl` - Firecrawl web scraping setup

## Changes

### `/setup-gemini` Command
- Checks prerequisites (Node.js v22+, pnpm, Claude Code)
- Guides through getting free Gemini API key from Google AI Studio
- Configures `GEMINI_API_KEY` in shell profile (.zshrc/.bashrc)
- Installs dependencies with `pnpm install`
- Registers MCP server using `claude mcp add`
- Uses inherited environment variables (no hardcoding in config files)
- Tests connection and shows usage examples

### `/setup-firecrawl` Command
- Checks prerequisites (curl, jq)
- Guides through getting Firecrawl API key (300 free credits)
- Configures `FIRECRAWL_API_KEY` in shell profile
- Explains both scraping scripts:
  - `firecrawl-scrape.sh` - single URL with custom filename
  - `firecrawl-batch.sh` - multiple URLs with auto-generated names
- Shows research workflow patterns
- Tests with sample scrape

## Best Practices Followed

- **No hardcoded secrets**: API keys only in shell environment
- **Clean config files**: MCP servers inherit env vars automatically
- **Gitignored configs**: `.mcp.json` stays local and secure
- **Interactive wizards**: Step-by-step guidance for new users
- **Comprehensive docs**: References to detailed troubleshooting guides

## Testing

Both commands tested successfully:
- Environment variable detection works
- MCP server registration creates clean config
- Scripts execute properly with inherited env vars

## References

- Referenced in `/init-bootstrap` lines 122 and 142
- Gemini Vision docs: `.claude/mcp-servers/GEMINI_VISION_QUICK_START.md`
- Firecrawl docs: `.scripts/README.md`

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)