### PR TITLE
fix: preserve CJK characters in filename sanitization

### DIFF
--- a/.scripts/firecrawl-batch.sh
+++ b/.scripts/firecrawl-batch.sh
@@ -44,9 +44,9 @@ CLIPPINGS_DIR="$OUTPUT_DIR"
 # Create clippings directory if it doesn't exist
 mkdir -p "$CLIPPINGS_DIR"
 
-# Function to sanitize filename
+# Function to sanitize filename (preserve CJK characters, only remove filesystem-illegal chars)
 sanitize_filename() {
-    echo "$1" | sed 's/[^a-zA-Z0-9 -]//g' | sed 's/ \+/ /g' | sed 's/^ *//;s/ *$//'
+    echo "$1" | sed 's/[\/\\:*?"<>|]//g' | sed 's/ \+/ /g' | sed 's/^ *//;s/ *$//'
 }
 
 # Function to extract domain name for fallback


### PR DESCRIPTION
## Summary

The current `sanitize_filename()` function removes all non-ASCII characters, causing CJK (Chinese/Japanese/Korean) titles to be completely stripped from filenames.

**Before fix:**
```
Title: "OwlMail：兼容 MailDev 的测试邮箱"
Filename: "2026-01-07 - OwlMail MailDev  -.md"
```

**After fix:**
```
Title: "OwlMail：兼容 MailDev 的测试邮箱"
Filename: "2026-01-07 - OwlMail：兼容 MailDev 的测试邮箱.md"
```

## Changes

- Modified `sanitize_filename()` to only remove filesystem-illegal characters (`/ \ : * ? " < > |`)
- Preserved Unicode text including CJK characters

## Test URL

You can reproduce this issue with any CJK webpage:

```bash
.scripts/firecrawl-batch.sh https://soulteary.com/2026/01/04/maildev-compatible-test-mailbox-owlmail.html
```

## Test plan

- [x] Tested with Chinese webpage title - filename now preserves Chinese characters
- [x] Verified illegal filesystem characters are still removed

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)