### PR TITLE
fix: replace sed with cut in /upgrade for zsh compatibility

### DIFF
--- a/.claude/commands/upgrade.md
+++ b/.claude/commands/upgrade.md
@@ -32,8 +32,9 @@ capabilities.
 - Check if already on latest version:
 
   ```bash
-  CURRENT=$(grep '"version"' package.json | sed 's/.*: "\(.*\)".*/\1/')
-  LATEST=$(curl -s https://raw.githubusercontent.com/heyitsnoah/claudesidian/main/package.json | grep '"version"' | sed 's/.*: "\(.*\)".*/\1/')
+  # Use cut instead of sed to avoid zsh parentheses escaping issues
+  CURRENT=$(grep '"version"' package.json | head -1 | cut -d'"' -f4)
+  LATEST=$(curl -s https://raw.githubusercontent.com/heyitsnoah/claudesidian/main/package.json | grep '"version"' | head -1 | cut -d'"' -f4)
 
   if [ "$CURRENT" = "$LATEST" ]; then
     echo "✅ You're already on the latest version ($CURRENT)"


### PR DESCRIPTION
## Summary

- Fix `/upgrade` command failing in zsh with `parse error near '('`
- Replace sed with cut for cross-shell compatibility

## Problem

The sed command with escaped parentheses fails in zsh:

```bash
# Fails in zsh
sed 's/.*: "\(.*\)".*/\1/'
# Error: (eval):1: parse error near `('
```

## Solution

Replace with simpler cut command that works across all shells:

```bash
# Works in bash, zsh, and other shells
cut -d'"' -f4
```

## Test plan

- [x] Tested in zsh on macOS
- [x] Verified version extraction works correctly

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)