### PR TITLE
feat: Add OpenCode support as alternative to Claude Code

### DIFF
--- a/.claude/commands/init-bootstrap.md
+++ b/.claude/commands/init-bootstrap.md
@@ -9,8 +9,32 @@ argument-hint: "(optional) path to existing vault or 'new' for fresh setup"
 
 # Initialize Bootstrap Configuration
 
-This command helps you create a personalized CLAUDE.md configuration file by
-asking questions about your Obsidian workflow and preferences.
+This command helps you create a personalized configuration file by asking
+questions about your Obsidian workflow and preferences.
+
+## Environment Detection
+
+**IMPORTANT**: This setup works with both Claude Code and OpenCode. Detect which
+environment is running:
+
+```bash
+# Check for OpenCode markers
+if [ -d ".opencode" ] && [ -f "opencode.json" ]; then
+  TOOL="opencode"
+  CONFIG_DIR=".opencode"
+  CONFIG_FILE=".opencode/config.json"
+elif [ -d ".claude" ]; then
+  TOOL="claude-code"
+  CONFIG_DIR=".claude"
+  CONFIG_FILE=".claude/vault-config.json"
+fi
+```
+
+When configuring:
+- **Claude Code**: Use `.claude/vault-config.json` for preferences
+- **OpenCode**: Use `.opencode/config.json` for preferences
+- Both use the same CLAUDE.md for user-facing instructions
+- Both share the same vault structure and commands
 
 ## Task
 
@@ -146,8 +170,10 @@ Then generate a customized CLAUDE.md file tailored to their needs.
      - Show example usage: `.scripts/firecrawl-scrape.sh https://example.com`
 
 6. **Generate Custom Configuration**
-   - Get current date: `date +"%B %d, %Y"` for the CLAUDE.md header
-   - Save preferences to `.claude/vault-config.json`:
+    - Get current date: `date +"%B %d, %Y"` for the CLAUDE.md header
+    - Save preferences to the appropriate config file based on tool detected:
+      - Claude Code: `.claude/vault-config.json`
+      - OpenCode: `.opencode/config.json`
      ```json
      {
        "user": {

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -1,0 +1,131 @@
+# OpenCode Setup for Claudesidian
+
+This directory contains configuration for [OpenCode](https://github.com/sst/opencode), an open-source alternative to Claude Code.
+
+## Quick Start
+
+1. Install OpenCode following [their documentation](https://github.com/sst/opencode)
+2. Run OpenCode in this directory: `opencode`
+3. Run the setup wizard: `/init-bootstrap`
+
+## Directory Structure
+
+```
+.opencode/
+├── opencode.json          # Main configuration (permissions, MCP)
+├── command/               # Slash commands (equivalent to .claude/commands/)
+│   ├── thinking-partner.md
+│   ├── daily-review.md
+│   ├── research-assistant.md
+│   └── ... (15 commands total)
+├── skills/                # Skills (equivalent to .claude/skills/)
+│   ├── obsidian-markdown/SKILL.md
+│   ├── systematic-debugging/SKILL.md
+│   └── ... (6 skills total)
+└── plugin/                # TypeScript plugins (equivalent to .claude/hooks/)
+    └── session-hooks.ts   # First-run welcome, update checking, skill discovery
+```
+
+## Differences from Claude Code
+
+| Feature | Claude Code | OpenCode |
+|---------|-------------|----------|
+| Config file | `.claude/settings.json` | `opencode.json` |
+| Commands | `.claude/commands/*.md` | `.opencode/command/*.md` |
+| Skills | `.claude/skills/*/SKILL.md` | `.opencode/skills/*/SKILL.md` |
+| Hooks | Bash scripts in `.claude/hooks/` | TypeScript in `.opencode/plugin/` |
+| Frontmatter | `allowed-tools`, `argument-hint` | `description` only |
+
+## Configuration
+
+### opencode.json
+
+The main config file supports:
+
+- **permission.autoApprove**: Tools that run without confirmation
+- **mcp**: MCP server definitions
+- **instructions**: Global system instructions
+
+Note: Model configuration is handled by your OpenCode setup, not this file.
+
+### Commands
+
+Commands use simplified frontmatter:
+
+```yaml
+---
+description: Brief description of what this command does
+---
+
+# Command instructions here...
+```
+
+### Skills
+
+Skills work identically to Claude Code - place `SKILL.md` files in subdirectories of `.opencode/skills/`.
+
+### Plugins
+
+Plugins are TypeScript modules that can hook into:
+
+- `onSessionStart`: Run on session initialization
+- `UserPromptSubmit`: Run when user submits a prompt
+- `PreToolUse` / `PostToolUse`: Run before/after tool execution
+
+The plugin dependency `@opencode-ai/plugin` is included in package.json.
+
+## MCP Servers
+
+The Gemini Vision MCP server is pre-configured. To enable:
+
+1. Get a free API key from [Google AI Studio](https://aistudio.google.com)
+2. Set the environment variable: `export GEMINI_API_KEY="your-key"`
+
+## Available Commands
+
+Run with `/command-name`:
+
+- `/thinking-partner` - Collaborative exploration
+- `/daily-review` - End of day reflection
+- `/weekly-synthesis` - Weekly patterns
+- `/research-assistant` - Deep topic research
+- `/inbox-processor` - Organize inbox items
+- `/create-command` - Build new commands
+- `/de-ai-ify` - Remove AI jargon
+- `/upgrade` - Update claudesidian
+- `/pragmatic-review` - Code review
+- `/add-frontmatter` - Add YAML frontmatter
+- `/release` - Version and release
+- `/install-claudesidian-command` - Shell alias
+- `/download-attachment` - Download files
+- `/pull-request` - Create PRs
+- `/init-bootstrap` - Setup wizard
+
+## Available Skills
+
+Invoke by mentioning "skill" in your prompt or loading directly:
+
+- `obsidian-markdown` - Obsidian syntax (wikilinks, callouts, embeds)
+- `obsidian-bases` - Database views (.base files)
+- `json-canvas` - Visual canvases (.canvas files)
+- `systematic-debugging` - Debug methodology
+- `git-worktrees` - Parallel development
+- `skill-creator` - Create new skills
+
+## Troubleshooting
+
+### Commands not found
+
+Ensure you're running OpenCode from the vault root directory where `opencode.json` exists.
+
+### MCP servers not working
+
+Check that environment variables are set before starting OpenCode:
+```bash
+export GEMINI_API_KEY="your-key"
+opencode
+```
+
+### Plugin errors
+
+Run `pnpm install` to ensure `@opencode-ai/plugin` is installed.

--- a/.opencode/command/add-frontmatter.md
+++ b/.opencode/command/add-frontmatter.md
@@ -1,0 +1,95 @@
+---
+description: Add or update YAML frontmatter properties to enhance note organization
+---
+
+# Add Frontmatter
+
+Analyze Obsidian notes and add intelligent YAML frontmatter properties
+to enhance organization and discoverability.
+
+## Input
+
+- Path: $ARGUMENTS (file or folder to process)
+
+## Process
+
+### Step 1: Identify Notes to Process
+
+If single file, read it. If folder, find all .md files.
+
+### Step 2: Analyze Note Content
+
+For each note, examine:
+- Main topics and themes
+- Note type (meeting, daily, reference, project)
+- Key entities (people, projects, dates)
+- Existing properties (preserve valid ones)
+
+### Step 3: Generate Appropriate Properties
+
+#### Meeting Notes:
+```yaml
+---
+title: [Descriptive meeting title]
+date: YYYY-MM-DD
+type: meeting
+attendees: ['Person 1', 'Person 2']
+tags: [meeting, project-name]
+status: complete
+---
+```
+
+#### Daily Notes:
+```yaml
+---
+title: Daily Note - YYYY-MM-DD
+date: YYYY-MM-DD
+type: daily-note
+tags: [daily]
+---
+```
+
+#### Reference/Article Notes:
+```yaml
+---
+title: [Article title]
+type: reference
+source: URL or [[Note]]
+tags: [topic1, topic2]
+---
+```
+
+#### Project Notes:
+```yaml
+---
+title: [Project Name]
+type: project
+status: in-progress
+deadline: YYYY-MM-DD
+priority: high
+---
+```
+
+### Step 4: Apply Properties
+
+1. Check for existing frontmatter
+2. Merge new properties (don't duplicate)
+3. Fix deprecated formats (tag → tags, alias → aliases)
+4. Ensure valid YAML syntax
+
+## Property Guidelines
+
+- Use lowercase with underscores: `date_created`
+- Be consistent with existing patterns
+- Prefer clear over clever names
+
+## Quality Checks
+
+- ✅ Valid YAML syntax
+- ✅ No duplicate properties
+- ✅ Appropriate property types
+- ✅ Quoted internal links
+- ✅ Meaningful values (not empty)
+
+Properties should enhance organization, not clutter. Only add what provides
+value for finding and connecting notes.

--- a/.opencode/command/create-command.md
+++ b/.opencode/command/create-command.md
@@ -1,0 +1,70 @@
+---
+description: Create a new OpenCode slash command
+---
+
+# Create New Slash Command
+
+I'll help you create a new OpenCode slash command.
+
+## Your Input
+
+**Command Details:** $ARGUMENTS
+
+## Process
+
+1. **Understand Requirements**
+   - What should the command do?
+   - What tools does it need?
+   - What output should it produce?
+
+2. **Design Structure**
+   - Command name (kebab-case)
+   - Required tools
+   - Input arguments
+   - Output format
+
+3. **Create Command File**
+   - Location: `.opencode/command/[command-name].md`
+   - Include proper frontmatter
+   - Clear instructions
+   - Example usage
+
+## Command Template
+
+```markdown
+---
+description: [One-line description]
+---
+
+# Command Name
+
+Brief description of what this command does.
+
+## Task
+
+[Clear description of the task]
+
+## Process
+
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+## Output
+
+[Expected output format]
+
+## Example Usage
+
+/command-name [arguments]
+```
+
+## Best Practices
+
+- Keep commands focused on one task
+- Use clear, descriptive names
+- Include example usage
+- Document required arguments
+- Specify output format
+
+Let me help you create your command!

--- a/.opencode/command/daily-review.md
+++ b/.opencode/command/daily-review.md
@@ -1,0 +1,59 @@
+---
+description: End-of-day review to capture progress and plan tomorrow
+---
+
+# Daily Review
+
+You are a daily review facilitator helping capture the day's progress and set up
+tomorrow for success.
+
+## Process
+
+1. **Review Today**
+   - What did you work on today?
+   - What progress did you make?
+   - Any blockers or challenges?
+   - What surprised you?
+
+2. **Capture Insights**
+   - Any "aha" moments to save?
+   - Connections to existing notes?
+   - Ideas worth exploring later?
+
+3. **Plan Tomorrow**
+   - Top 3 priorities
+   - Any meetings or deadlines?
+   - What would make tomorrow successful?
+
+## Output Format
+
+Create or update a daily note in the format:
+
+```markdown
+---
+date: YYYY-MM-DD
+type: daily-note
+---
+
+# Daily Review - [Date]
+
+## Progress
+- [Accomplishments]
+
+## Insights
+- [Key learnings]
+
+## Tomorrow
+- [ ] Priority 1
+- [ ] Priority 2
+- [ ] Priority 3
+
+## Notes
+[Any additional context]
+```
+
+## Tips
+
+- Keep it concise (5-10 minutes)
+- Link to relevant notes with [[wikilinks]]
+- Don't overthink - capture what's top of mind

--- a/.opencode/command/de-ai-ify.md
+++ b/.opencode/command/de-ai-ify.md
@@ -1,0 +1,90 @@
+---
+description: Remove AI-generated jargon and restore human voice to text
+---
+
+# De-AI-ify Text
+
+Remove AI-generated patterns and restore natural human voice to your writing.
+
+## Processing: $ARGUMENTS
+
+I'll create a de-AI-ified version of your text that sounds more human and less
+machine-generated.
+
+## What Gets Removed
+
+### 1. Overused Transitions
+
+- "Moreover," "Furthermore," "Additionally," "Nevertheless"
+- Excessive "However" usage
+- "While X, Y" openings
+
+### 2. AI Clichés
+
+- "In today's fast-paced world"
+- "Let's dive deep"
+- "Unlock your potential"
+- "Harness the power of"
+
+### 3. Hedging Language
+
+- "It's important to note"
+- "It's worth mentioning"
+- Vague quantifiers: "various," "numerous," "myriad"
+
+### 4. Corporate Buzzwords
+
+- "utilize" → "use"
+- "facilitate" → "help"
+- "optimize" → "improve"
+- "leverage" → "use"
+
+### 5. Robotic Patterns
+
+- Rhetorical questions followed by immediate answers
+- Obsessive parallel structures
+- Always using exactly three examples
+- Announcement of emphasis
+
+## What Gets Added
+
+### Natural Voice
+
+- Varied sentence lengths
+- Conversational tone
+- Direct statements
+- Specific examples
+
+### Human Rhythm
+
+- Natural transitions
+- Confident assertions
+- Personal perspective
+- Authentic phrasing
+
+## Process
+
+1. **Read original file**
+2. **Create copy with "-HUMAN" suffix**
+3. **Apply de-AI-ification**
+4. **Provide change log**
+
+## Output
+
+You'll get:
+
+- A new file with natural human voice
+- Change log showing what was fixed
+- List of places needing specific examples
+
+## Example Transformations
+
+**Before (AI):** "In today's rapidly evolving digital landscape, it's crucial to
+understand that leveraging AI effectively isn't just about utilizing
+cutting-edge technology—it's about harnessing its transformative potential to
+unlock unprecedented opportunities."
+
+**After (Human):** "AI works best when you use it for specific tasks. Focus on
+what it does well: writing code, analyzing data, and answering questions."
+
+Let me de-AI-ify your text!

--- a/.opencode/command/download-attachment.md
+++ b/.opencode/command/download-attachment.md
@@ -1,0 +1,78 @@
+---
+description: Download files from URLs to attachments folder and organize them
+---
+
+# Download Attachment
+
+Download files from URLs to attachments folder and organize them with
+descriptive names.
+
+## Usage
+
+```
+/download-attachment <url1> [url2] [url3...]
+```
+
+## Examples
+
+```
+/download-attachment https://example.com/document.pdf
+/download-attachment https://site.com/image.png https://site.com/report.pdf
+```
+
+## Process
+
+### Step 1: Parse and Validate URLs
+
+- Extract URL(s) from input
+- Validate URL scheme (only http:// or https://)
+- Reject invalid URLs
+
+### Step 2: Download Files
+
+```bash
+# Sanitize filename
+filename=$(basename "$url" | sed 's/[^a-zA-Z0-9._-]/_/g')
+
+# Download with timeout
+curl --max-time 30 -L "$url" -o "05_Attachments/$filename"
+```
+
+### Step 3: Verify Downloads
+
+Check files were downloaded successfully.
+
+### Step 4: Organize Files
+
+After downloading:
+- For PDFs: Extract text and analyze for meaningful title
+- For Images: Use vision analysis for descriptive filename
+
+### Step 5: Move to Organized
+
+Move renamed files to `05_Attachments/Organized/` with descriptive names.
+
+### Step 6: Update Index
+
+Add entries to `05_Attachments/00_Index.md`
+
+## Supported Types
+
+- Images: .png, .jpg, .jpeg, .gif, .webp
+- Documents: .pdf, .doc, .docx
+- Text: .txt, .md
+- Data: .csv, .xlsx
+
+## Workflow
+
+1. Download file(s) from provided URL(s)
+2. Identify file type and analyze content
+3. Generate descriptive filename
+4. Move to Organized folder
+5. Update index and references
+
+## Tips
+
+- For multiple URLs, process in batch
+- Keep filenames concise but descriptive (max 60 chars)
+- Preserve original file extensions

--- a/.opencode/command/inbox-processor.md
+++ b/.opencode/command/inbox-processor.md
@@ -1,0 +1,78 @@
+---
+description: Process and organize items in the Inbox folder
+---
+
+# Inbox Processor
+
+You are an inbox processing assistant helping organize captured items into their
+appropriate PARA locations.
+
+## Process
+
+1. **Review Inbox**
+   - List all items in 00_Inbox/
+   - For each item, identify:
+     - What is it? (note, idea, task, reference)
+     - What's it related to?
+     - Is it actionable?
+
+2. **Categorize Each Item**
+   - **Project-related** → Move to relevant 01_Projects/ folder
+   - **Area-related** → Move to relevant 02_Areas/ folder
+   - **Reference material** → Move to 03_Resources/
+   - **Completed/irrelevant** → Move to 04_Archive/ or delete
+   - **Needs more thought** → Leave in inbox with a note
+
+3. **Process Each Item**
+   - Add appropriate frontmatter
+   - Create wikilinks to related notes
+   - Add tags if relevant
+   - Rename if needed for clarity
+
+4. **Clean Up**
+   - Verify items are in correct locations
+   - Remove any empty files
+   - Update any affected index notes
+
+## Decision Tree
+
+```
+Is this actionable?
+├── Yes → Is it part of a project?
+│   ├── Yes → 01_Projects/[Project]/
+│   └── No → Is it an ongoing responsibility?
+│       ├── Yes → 02_Areas/[Area]/
+│       └── No → 00_Inbox/ (needs project/area)
+└── No → Is it reference material?
+    ├── Yes → 03_Resources/[Topic]/
+    └── No → 04_Archive/ or delete
+```
+
+## Output
+
+After processing, provide a summary:
+
+```markdown
+## Inbox Processing Summary
+
+**Processed:** X items
+**Moved to Projects:** X
+**Moved to Areas:** X  
+**Moved to Resources:** X
+**Archived:** X
+**Remaining in Inbox:** X
+
+### Actions Taken
+- [Item] → [Destination]
+- [Item] → [Destination]
+
+### Items Needing Attention
+- [Item] - [Reason]
+```
+
+## Tips
+
+- Process inbox regularly (daily or weekly)
+- When in doubt, leave it and revisit later
+- Create new folders if needed
+- Link related items as you process

--- a/.opencode/command/init-bootstrap.md
+++ b/.opencode/command/init-bootstrap.md
@@ -1,0 +1,167 @@
+---
+description: Interactive setup wizard to create personalized configuration
+---
+
+# Initialize Bootstrap Configuration
+
+This command helps you create a personalized configuration file by asking
+questions about your Obsidian workflow and preferences.
+
+## Environment Detection
+
+**IMPORTANT**: This setup works with both Claude Code and OpenCode. Detect which
+environment is running:
+
+```bash
+# Check for OpenCode markers
+if [ -d ".opencode" ] && [ -f "opencode.json" ]; then
+  TOOL="opencode"
+  CONFIG_DIR=".opencode"
+  CONFIG_FILE=".opencode/config.json"
+elif [ -d ".claude" ]; then
+  TOOL="claude-code"
+  CONFIG_DIR=".claude"
+  CONFIG_FILE=".claude/vault-config.json"
+fi
+```
+
+When configuring:
+- **Claude Code**: Use `.claude/vault-config.json` for preferences
+- **OpenCode**: Use `.opencode/config.json` for preferences
+- Both use the same CLAUDE.md for user-facing instructions
+- Both share the same vault structure and commands
+
+## Task
+
+Read the CLAUDE-BOOTSTRAP.md template and interactively gather information about
+the user's workflow to generate a customized configuration file.
+
+## Process
+
+### 1. Initial Environment Setup
+
+- Get current date with `date` command for timestamps
+- Check current folder name and ask if they want to rename it
+- Check for package.json and install dependencies (pnpm preferred, npm fallback)
+- Check git status:
+  - If no .git folder: Initialize git repository
+  - If has remote origin: Ask about development vs personal vault
+- Don't create folders yet - wait until after asking about organization method
+
+### 2. Check Existing Configuration
+
+- Look for existing CLAUDE.md or OpenCode configuration
+- If exists, ask if they want to update or start fresh
+- Check for CLAUDE-BOOTSTRAP.md template
+
+### 3. Gather Vault Information
+
+Search common locations for existing Obsidian vaults:
+- `~/Documents` (maxdepth 3)
+- `~/Desktop` (maxdepth 3)
+- `~/Library/Mobile Documents/iCloud~md~obsidian/Documents` (macOS only)
+- Home directory (maxdepth 2)
+
+If found, analyze vault structure:
+- Run `tree -L 3 -d [path]` to see folder hierarchy
+- Sample notes to understand content types
+- Detect organization system (PARA, Zettelkasten, etc.)
+
+### 4. Ask Configuration Questions
+
+- "What's your name?" (for personalization)
+- "Would you like me to research your public work?"
+- "Do you follow the PARA method or have a different organization system?"
+- "What are your main use cases?" (research, writing, projects, daily notes)
+
+**If using PARA:**
+- "What active projects are you working on?"
+- "What areas of responsibility do you maintain?"
+- "What topics do you research frequently?"
+
+**General preferences:**
+- Check existing plugins
+- Detect naming conventions
+- Ask about git usage
+- Ask about writing style preferences
+
+### 5. Optional Tool Setup
+
+**Gemini Vision (already included)**
+- Ask if they want to activate it
+- Guide API key setup if yes
+
+**Firecrawl (already included)**
+- Ask if they want to set it up
+- Guide API key setup if yes
+
+### 6. Generate Custom Configuration
+
+- Save preferences to the appropriate config file based on tool detected:
+  - Claude Code: `.claude/vault-config.json`
+  - OpenCode: `.opencode/config.json`
+- Start with template as base
+- Add user-specific sections:
+  - Custom folder structure
+  - Personal workflows
+  - Preferred tools and scripts
+
+### 7. Import Existing Vault (if applicable)
+
+- Create OLD_VAULT folder
+- Copy entire vault preserving structure
+- Copy Obsidian configuration
+- Show summary of imported files
+
+### 8. Create Supporting Files
+
+- Generate folder structure if new vault
+- Create README files for main folders
+- Set up project subfolders (Research/, Chats/, Daily Progress/)
+- Create 05_Attachments/Organized/ directory
+- Set up .gitignore if using git
+- Remove FIRST_RUN marker file if exists
+
+### 9. Run Test Commands
+
+- Execute `pnpm vault:stats` to verify scripts work
+- Test MCP tools if configured
+- Verify git is tracking correctly
+
+### 10. Provide Next Steps
+
+- Summary of what was created
+- Quick start guide
+- List of available commands
+- Test commands to verify setup
+
+## Important Notes
+
+### Handling Multiple Vaults
+
+When multiple vaults detected:
+1. List all vaults with clear numbering
+2. Require explicit selection
+3. Confirm before proceeding
+
+### Platform Compatibility
+
+Works on Linux, macOS, and Windows (WSL/Git Bash):
+- iCloud vault detection is macOS only
+- Standard locations work on all platforms
+
+### User Path Validation
+
+When users provide vault path:
+- Expand tilde to home directory
+- Validate path exists
+- Check for .obsidian folder
+- Verify read permissions
+
+## Example Usage
+
+```
+/init-bootstrap
+/init-bootstrap new
+/init-bootstrap ~/Documents/MyVault
+```

--- a/.opencode/command/install-claudesidian-command.md
+++ b/.opencode/command/install-claudesidian-command.md
@@ -1,0 +1,94 @@
+---
+description: Install claudesidian shell command to launch from anywhere
+---
+
+# Install Claudesidian Command
+
+Creates a shell alias/function that allows you to run `claudesidian` from
+anywhere to open your vault in OpenCode or Claude Code.
+
+## Task
+
+Install a shell command that:
+1. Changes to your claudesidian vault directory
+2. Launches your preferred AI coding assistant
+3. Works from any directory in your terminal
+
+## Process
+
+### 1. Detect Current Setup
+
+- Check which shell (bash/zsh/fish)
+- Find the current working directory (vault path)
+- Determine the appropriate config file
+
+### 2. Create the Command
+
+The command will be an alias that:
+- Changes to vault directory
+- Tries to resume existing session
+- Falls back to new session if none exists
+
+### 3. Install to Shell Config
+
+Add the alias to:
+- **Bash**: `~/.bashrc` or `~/.bash_profile`
+- **Zsh**: `~/.zshrc`
+- **Fish**: `~/.config/fish/config.fish`
+
+### 4. Verify Installation
+
+- Show the added line
+- Remind user to reload shell
+- Provide test command
+
+## Shell Commands Created
+
+**For OpenCode users:**
+```bash
+alias claudesidian='(cd "/path/to/vault" && (opencode --resume 2>/dev/null || opencode))'
+```
+
+**For Claude Code users:**
+```bash
+alias claudesidian='(cd "/path/to/vault" && (claude --resume 2>/dev/null || claude))'
+```
+
+## Example Output
+
+```
+🔧 Installing claudesidian command...
+
+📁 Vault path: /home/user/my-vault
+🐚 Shell detected: zsh
+📝 Config file: ~/.zshrc
+
+💾 Backup created: ~/.zshrc.backup-20250107-143025
+
+✅ Installed! Added to ~/.zshrc:
+   alias claudesidian='(cd "/home/user/my-vault" && ...)'
+
+🔄 To activate, run:
+   source ~/.zshrc
+
+✨ Test it: Type 'claudesidian' from any directory!
+```
+
+## Usage Examples
+
+```bash
+# Install for default shell (auto-detected)
+/install-claudesidian-command
+
+# Install for specific shell
+/install-claudesidian-command zsh
+/install-claudesidian-command bash
+/install-claudesidian-command fish
+```
+
+## Security Considerations
+
+- You'll see exactly what will be added before changes
+- Timestamped backup is created automatically
+- Vault path is properly escaped
+- Asks permission before replacing existing commands

--- a/.opencode/command/pragmatic-review.md
+++ b/.opencode/command/pragmatic-review.md
@@ -1,0 +1,66 @@
+---
+description: Interactive pragmatic code review focusing on YAGNI and KISS principles
+---
+
+# Pragmatic Code Review: YAGNI & KISS Focus
+
+Perform an interactive code review with laser focus on **YAGNI** (You
+Aren't Gonna Need It) and **KISS** (Keep It Simple, Stupid) principles.
+
+## Review Modes
+
+**Default mode**: Fast YAGNI/KISS-focused review
+- Scans for over-engineering, unused abstractions, unnecessary complexity
+- Quick security and performance checks
+
+**Deep mode** (`--deep` flag): Multi-pass comprehensive review
+- Pass 1: Security (OWASP Top 10)
+- Pass 2: Architecture (SOLID principles)
+- Pass 3: Logic (edge cases, error handling)
+- Pass 4: Performance (algorithm complexity)
+- Pass 5: YAGNI/KISS (over-engineering)
+- Pass 6: Maintainability (readability, tests)
+
+**CI mode** (`--ci` flag): Non-interactive for automation
+
+## YAGNI Detection Patterns
+
+1. **Unused abstractions** - Interfaces with single implementations
+2. **Premature flexibility** - Config for things that never change
+3. **Over-engineering** - Factory classes for simple objects
+4. **Speculative code** - "TODO: might need this" comments
+5. **GenericButton Anti-Pattern** - Components with 8+ optional parameters
+6. **Premature Abstraction** - Abstraction before 3rd duplication
+
+## KISS Violation Patterns
+
+1. **Verbose implementations** - Can be reduced by >50%
+2. **Abstraction addiction** - More than 3 levels of wrapping
+3. **Clever code** - Needs extensive comments to explain
+4. **Catch-Log-Exit** - Catching exceptions just to log and exit
+
+## Issue Severity Prefixes
+
+| Prefix | Meaning | Action |
+|--------|---------|--------|
+| `issue:` | Bug, correctness problem | Must fix |
+| `nit:` | Minor improvement | Optional |
+| `thought:` | Design consideration | Discuss |
+| `suggestion:` | Specific improvement | Consider |
+
+## Command Parameters
+
+- `--auto` : Skip prompts, use defaults
+- `--ci` : CI mode, non-interactive
+- `--deep` : 6-pass comprehensive review
+- `--branch [name]` : Review specific branch
+- `--base [branch]` : Compare against base
+
+## Core Philosophy
+
+1. **YAGNI**: Features cost 4x: build, carry, repair, opportunity
+2. **KISS**: Debugging is twice as hard as writing
+3. **Rule of Three**: Tolerate duplication twice, refactor on third
+4. **Pragmatic**: Ship working software today, perfect it tomorrow
+
+Every line deleted is a victory.

--- a/.opencode/command/pull-request.md
+++ b/.opencode/command/pull-request.md
@@ -1,0 +1,121 @@
+---
+description: Create a feature branch, commit, push, and open a pull request
+---
+
+# Pull Request Command
+
+Creates a new feature branch, commits changes, pushes to GitHub, and opens a
+pull request - all in one command.
+
+## Task
+
+Automate the entire pull request workflow: create branch, stage changes, commit
+with descriptive message, push to GitHub, and open PR with proper description.
+
+## Process
+
+### 1. Check Prerequisites
+
+- Ensure git repository exists
+- Check for uncommitted changes
+- Verify GitHub CLI (`gh`) is available
+- Get current branch as base
+
+### 2. Create Feature Branch
+
+```bash
+# Generate sanitized branch name
+branch_name=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+
+# Format: feature/short-description or fix/issue-name
+git checkout -b $branch_name
+```
+
+### 3. Stage and Review Changes
+
+- Show `git status` to user
+- Show `git diff --staged` for review
+- Stage all changes if none staged
+- Confirm with user
+
+### 4. Commit Changes
+
+Use conventional commits format:
+```bash
+git commit -m "feat: add new feature
+
+- Detail 1
+- Detail 2"
+```
+
+### 5. Push to GitHub
+
+```bash
+git push -u origin $branch_name
+```
+
+### 6. Create Pull Request
+
+```bash
+gh pr create \
+  --title "Feature: Add awesome capability" \
+  --body "## Summary
+Brief description
+
+## Changes
+- Added X
+- Fixed Y
+
+## Testing
+- [ ] Tested locally
+- [ ] All tests pass" \
+  --base main
+```
+
+### 7. Provide Next Steps
+
+- Show PR URL
+- Remind about review process
+
+## Arguments
+
+- **Optional**: Branch name (auto-generated if not provided)
+- **Optional**: PR title (analyzed from changes if not provided)
+- **Optional**: Target branch (defaults to main/master)
+
+## Example Usage
+
+```bash
+# Auto-generate from changes
+/pull-request
+
+# Specify branch name
+/pull-request feature/add-auth
+
+# Full specification
+/pull-request fix/bug-123 "Fix timeout issue" develop
+```
+
+## Branch Naming Conventions
+
+- **Features**: `feature/description`
+- **Fixes**: `fix/issue-or-description`
+- **Documentation**: `docs/what-updated`
+- **Refactoring**: `refactor/what-changed`
+
+## Commit Message Format
+
+- `feat:` New feature
+- `fix:` Bug fix
+- `docs:` Documentation only
+- `refactor:` Code change
+- `perf:` Performance improvement
+- `test:` Adding tests
+- `chore:` Build/tooling changes
+
+## Safety Features
+
+- Confirm before pushing large changes
+- Show diff before committing
+- Verify PR description before creating
+- Handle merge conflicts gracefully

--- a/.opencode/command/release.md
+++ b/.opencode/command/release.md
@@ -1,0 +1,90 @@
+---
+description: Automatically bump version, update changelog, commit, tag, and push a release
+---
+
+# Release Command
+
+Automates the entire release process: analyzes recent commits to determine
+version bump type, updates version in package.json, moves unreleased changelog
+entries to the new version, commits everything, creates a git tag, and pushes to
+GitHub.
+
+## Task
+
+1. Analyze recent commits since last tag to determine version bump type
+2. Update version in package.json
+3. Move "Unreleased" entries in CHANGELOG.md to the new version section
+4. Commit the changes
+5. Create an annotated git tag
+6. Push commits and tags to GitHub
+7. Create GitHub release with release notes
+
+## Process
+
+### 1. Check Prerequisites
+
+- Ensure on main/master branch
+- Check for uncommitted changes
+- Verify CHANGELOG.md and package.json exist
+
+### 2. Determine Version Bump
+
+If argument provided (major/minor/patch), use that. Otherwise analyze commits:
+- "BREAKING CHANGE" or "!" = major bump
+- "feat:" = minor bump  
+- "fix:", "docs:", "chore:" = patch bump
+
+### 3. Update Files
+
+- Update version in package.json
+- Move "Unreleased" to new version section in CHANGELOG.md
+- Add comparison links
+
+### 4. Git Operations
+
+```bash
+git add package.json CHANGELOG.md
+git commit -m "chore: release v{version}"
+git tag -a v{version} -m "Release v{version}"
+git push && git push --tags
+```
+
+### 5. Create GitHub Release
+
+```bash
+gh release create v{version} --notes "..."
+```
+
+## Version Bump Rules
+
+**MAJOR** (1.0.0 → 2.0.0):
+- Breaking changes requiring user code changes
+- Removing features or changing syntax incompatibly
+
+**MINOR** (1.0.0 → 1.1.0):
+- NEW capabilities (not enhancements)
+- New commands, tools, integrations
+
+**PATCH** (1.0.0 → 1.0.1):
+- Bug fixes and improvements
+- Enhancements to existing features
+- Documentation updates
+
+## Example Usage
+
+```bash
+# Auto-detect version bump
+/release
+
+# Force specific bump
+/release patch
+/release minor
+/release major
+```
+
+## Safety Features
+
+- Dry run mode available
+- Confirmation before pushing
+- Version format validation
+- Check for existing tags

--- a/.opencode/command/research-assistant.md
+++ b/.opencode/command/research-assistant.md
@@ -1,0 +1,80 @@
+---
+description: Deep research assistant for thorough topic exploration
+---
+
+# Research Assistant
+
+You are a research assistant helping conduct thorough research on any topic
+using the vault's existing knowledge and external sources.
+
+## Process
+
+1. **Define the Question**
+   - What exactly are we trying to learn?
+   - What's the scope and depth needed?
+   - Any specific angles or perspectives to consider?
+
+2. **Search Existing Knowledge**
+   - Search the vault for relevant notes
+   - Check related projects and resources
+   - Look for prior research on this topic
+
+3. **Identify Gaps**
+   - What do we already know?
+   - What's missing?
+   - What sources should we consult?
+
+4. **Synthesize Findings**
+   - Combine vault knowledge with new research
+   - Create connections between sources
+   - Highlight contradictions or debates
+
+5. **Document Results**
+   - Create a research note with findings
+   - Link to source materials
+   - Note areas for further exploration
+
+## Output Format
+
+Create a research note:
+
+```markdown
+---
+date: YYYY-MM-DD
+type: research
+topic: [Topic Name]
+status: in-progress | complete
+---
+
+# Research: [Topic]
+
+## Research Question
+[The core question being investigated]
+
+## Key Findings
+1. [Finding 1]
+2. [Finding 2]
+3. [Finding 3]
+
+## Sources
+- [[Internal Note 1]]
+- [[Internal Note 2]]
+- [External Source](url)
+
+## Open Questions
+- [Questions that emerged]
+
+## Related Notes
+- [[Related Topic 1]]
+- [[Related Topic 2]]
+
+## Notes
+[Additional context and observations]
+```
+
+## Tips
+
+- Start with vault search before external research
+- Use specific search terms
+- Create links to preserve connections
+- Save valuable sources to 03_Resources/

--- a/.opencode/command/thinking-partner.md
+++ b/.opencode/command/thinking-partner.md
@@ -1,0 +1,48 @@
+---
+description: Collaborative thinking partner for exploring complex problems
+---
+
+# Thinking Partner
+
+You are a collaborative thinking partner specializing in helping people explore
+complex problems. Your role is to facilitate thinking through careful
+questioning and exploration, not to rush toward solutions.
+
+## Core Behaviors
+
+1. **Ask before answering** - Lead with questions that help clarify and deepen
+   understanding
+2. **Track insights** - Maintain a running log of key discoveries and
+   connections
+3. **Resist solutioning** - Stay in exploration mode until explicitly asked to
+   move forward
+4. **Connect ideas** - Help identify patterns and relationships across different
+   notes
+5. **Surface assumptions** - Gently challenge implicit beliefs and assumptions
+
+## Workflow
+
+When engaged as a thinking partner:
+
+1. Start by understanding the topic or challenge
+2. Search the vault for relevant existing notes
+3. Ask 3-5 clarifying questions
+4. As the conversation develops:
+   - Take notes on key insights
+   - Identify connections to other ideas
+   - Track open questions
+   - Note potential directions to explore
+5. Periodically summarize what's emerging
+
+## Key Prompts You Might Use
+
+- "What's behind that thought?"
+- "How does this connect to [other concept] you mentioned?"
+- "What would the opposite look like?"
+- "What's the real challenge here?"
+- "What are we not considering?"
+
+## Remember
+
+The goal is not to have answers but to help discover them. Your value is in the
+quality of exploration, not the speed of resolution.

--- a/.opencode/command/upgrade.md
+++ b/.opencode/command/upgrade.md
@@ -1,0 +1,70 @@
+---
+description: Intelligently upgrade claudesidian with new features while preserving user customizations
+---
+
+# Smart Upgrade Command
+
+Intelligently upgrades your claudesidian installation by fetching the latest
+release from GitHub and using AI-powered semantic analysis to merge new features
+with your existing customizations. Preserves user intent while adding new
+capabilities.
+
+## Task
+
+1. Check GitHub for the latest claudesidian release
+2. Download and analyze what has changed since your version
+3. Use Claude's semantic understanding to identify user customizations
+4. Intelligently merge new features with existing customizations
+5. Safely apply updates while preserving user data and preferences
+6. Create backups and provide rollback options
+
+## Process
+
+### 1. **Version Check & Setup**
+
+- Get current version from package.json
+- Check if already on latest version
+- Create timestamped backup in `.backup/upgrade-YYYY-MM-DD-HHMMSS/`
+- Clone latest claudesidian to temp directory
+
+### 2. **Create Upgrade Checklist**
+
+- Compare system files between current and latest
+- Create checklist of files that need review
+- Explicitly EXCLUDE user content (00_Inbox through 06_Metadata, CLAUDE.md)
+
+### 3. **File-by-File Review**
+
+For EACH file:
+1. Show diff between local and upstream
+2. Determine update strategy
+3. Ask user for decision on conflicting files
+4. Apply chosen strategy
+5. Update checklist status
+
+### 4. **Update Categories**
+
+**AI-Powered Merge**: Commands, Agents, Templates
+**Automatic Safe Updates**: New commands, Scripts, Dependencies
+**Never Modified**: User content, CLAUDE.md, API configs
+
+### 5. **Verification & Cleanup**
+
+- Verify all files updated correctly
+- Clean up temp directory
+- Show summary of changes
+
+## Command Usage
+
+```
+/upgrade check    # Preview what would be updated
+/upgrade          # Interactive upgrade
+/upgrade force    # Batch upgrade with auto-approve safe updates
+```
+
+## Safety Features
+
+- Complete backup before changes
+- File-by-file confirmation
+- Rollback support
+- User content always protected

--- a/.opencode/command/weekly-synthesis.md
+++ b/.opencode/command/weekly-synthesis.md
@@ -1,0 +1,72 @@
+---
+description: Weekly synthesis to find patterns and insights across the week
+---
+
+# Weekly Synthesis
+
+You are a weekly synthesis facilitator helping identify patterns, progress, and
+areas for adjustment across the past week.
+
+## Process
+
+1. **Gather Data**
+   - Review daily notes from the past 7 days
+   - Check project progress and updates
+   - Look at completed tasks and open items
+
+2. **Identify Patterns**
+   - What themes emerged this week?
+   - Where did you spend most of your time?
+   - What worked well? What didn't?
+   - Any recurring blockers?
+
+3. **Extract Insights**
+   - Key learnings worth preserving
+   - Connections between different work streams
+   - Ideas that kept coming up
+
+4. **Plan Adjustments**
+   - What should continue?
+   - What should stop?
+   - What should start?
+
+## Output Format
+
+Create a weekly note:
+
+```markdown
+---
+date: YYYY-MM-DD
+type: weekly-synthesis
+week: W##
+---
+
+# Weekly Synthesis - Week of [Date]
+
+## Accomplishments
+- [Key wins this week]
+
+## Patterns & Themes
+- [Recurring topics or activities]
+
+## Insights
+- [Key learnings]
+
+## Challenges
+- [Blockers or difficulties]
+
+## Next Week Focus
+- [ ] Priority 1
+- [ ] Priority 2
+- [ ] Priority 3
+
+## Notes
+[Additional reflections]
+```
+
+## Tips
+
+- Schedule a consistent time (e.g., Friday afternoon)
+- Review project folders for updates
+- Link to relevant daily notes and projects
+- Keep synthesis focused on actionable insights

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://opencode.ai/schema/opencode.json",
+  "permission": {
+    "autoApprove": ["Read", "Glob", "Grep", "WebFetch"]
+  },
+  "mcp": {
+    "gemini-vision": {
+      "type": "node",
+      "command": "node",
+      "args": [".claude/mcp-servers/gemini-vision.mjs"],
+      "env": {
+        "GEMINI_API_KEY": "${GEMINI_API_KEY}"
+      }
+    }
+  },
+  "instructions": [
+    "You are an AI assistant working within an Obsidian vault configured with the PARA method.",
+    "",
+    "## Vault Structure",
+    "- 00_Inbox/ - Temporary capture point for new ideas",
+    "- 01_Projects/ - Active, time-bound initiatives",
+    "- 02_Areas/ - Ongoing responsibilities",
+    "- 03_Resources/ - Reference materials and knowledge base",
+    "- 04_Archive/ - Completed projects and inactive items",
+    "- 05_Attachments/ - Images, PDFs, and other files",
+    "- 06_Metadata/ - Vault configuration and templates",
+    "",
+    "## Core Principles",
+    "1. **Thinking mode vs Writing mode** - Ask which mode before starting",
+    "2. **Search before creating** - Always check for existing notes first",
+    "3. **Use wikilinks** - Link notes with [[Note Name]] syntax",
+    "4. **Obsidian Markdown** - Use callouts, embeds, and properties",
+    "5. **Preserve context** - Save valuable conversations and insights",
+    "",
+    "## Available Commands",
+    "Run commands with /command-name:",
+    "- /thinking-partner - Collaborative exploration",
+    "- /daily-review - End of day reflection",
+    "- /weekly-synthesis - Weekly patterns and insights",
+    "- /research-assistant - Deep topic research",
+    "- /inbox-processor - Organize inbox items",
+    "- /create-command - Build new commands",
+    "- /de-ai-ify - Remove AI jargon from text",
+    "- /upgrade - Update claudesidian",
+    "- /init-bootstrap - Setup wizard",
+    "",
+    "## Skills",
+    "Skills provide specialized knowledge. Available:",
+    "- obsidian-markdown - Obsidian syntax expertise",
+    "- obsidian-bases - Database-like views",
+    "- json-canvas - Visual canvases",
+    "- systematic-debugging - Debug methodology",
+    "- git-worktrees - Parallel development",
+    "- skill-creator - Create new skills"
+  ]
+}

--- a/.opencode/plugin/session-hooks.ts
+++ b/.opencode/plugin/session-hooks.ts
@@ -1,0 +1,160 @@
+// Session hooks plugin for Claudesidian
+// Provides: first-run welcome, update checking, and skill discovery
+//
+// OpenCode equivalent of .claude/hooks/skill-discovery.sh and settings.json hooks
+
+import type {
+  PluginInput,
+  UserPromptSubmitContext,
+  UserPromptSubmitResult,
+} from "@opencode-ai/plugin";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join, basename } from "path";
+
+/**
+ * Claudesidian Session Hooks Plugin
+ *
+ * Features:
+ * 1. First-run welcome message with setup instructions
+ * 2. Update checking on session start
+ * 3. Skill discovery when user mentions "skill"
+ */
+export default function createClaudesidianPlugin(input: PluginInput) {
+  const { directory, $ } = input;
+
+  /**
+   * Check if this is the first run (FIRST_RUN file exists)
+   */
+  const isFirstRun = (): boolean => {
+    return existsSync(join(directory, "FIRST_RUN"));
+  };
+
+  /**
+   * Get available skills from .opencode/skill/ directory
+   */
+  const getSkills = (): Array<{ name: string; description: string }> => {
+    const skillsDir = join(directory, ".opencode", "skills");
+    const skills: Array<{ name: string; description: string }> = [];
+
+    if (!existsSync(skillsDir)) {
+      return skills;
+    }
+
+    try {
+      const dirs = readdirSync(skillsDir, { withFileTypes: true });
+      for (const dir of dirs) {
+        if (!dir.isDirectory()) continue;
+
+        const skillFile = join(skillsDir, dir.name, "SKILL.md");
+        if (existsSync(skillFile)) {
+          const content = readFileSync(skillFile, "utf-8");
+          // Extract description from YAML frontmatter
+          const descMatch = content.match(/^description:\s*(.+)$/m);
+          const description = descMatch ? descMatch[1].trim() : "";
+          skills.push({ name: dir.name, description });
+        } else {
+          skills.push({ name: dir.name, description: "" });
+        }
+      }
+    } catch {
+      // Silently handle errors
+    }
+
+    return skills.sort((a, b) => a.name.localeCompare(b.name));
+  };
+
+  /**
+   * Check if prompt mentions "skill" or "skills"
+   */
+  const mentionsSkill = (prompt: string): boolean => {
+    return /\bskills?\b/i.test(prompt);
+  };
+
+  return {
+    /**
+     * Session start hook
+     * - Shows first-run welcome message
+     * - Checks for updates
+     */
+    onSessionStart: async () => {
+      const messages: string[] = [];
+
+      // First run welcome
+      if (isFirstRun()) {
+        messages.push(`
+# 🚀 Welcome to Claudesidian!
+
+**This appears to be your first time using this vault.**
+
+## Quick Start
+
+Run the setup wizard:
+
+⬇
+/init-bootstrap
+⬆
+
+## What this will do:
+
+✅ Set up your personalized configuration
+✅ Disconnect from the original repository
+✅ Help you import any existing Obsidian vault
+✅ Configure your preferred workflow
+✅ Create your PARA folder structure
+
+The setup wizard will guide you through everything!
+`);
+      }
+
+      // Check for updates (suppress errors)
+      try {
+        const result = await $`npm run check-updates --silent 2>/dev/null`;
+        if (result.stdout.trim()) {
+          messages.push(result.stdout.trim());
+        }
+      } catch {
+        // Silently ignore update check failures
+      }
+
+      if (messages.length > 0) {
+        console.log(messages.join("\n\n"));
+      }
+    },
+
+    /**
+     * User prompt submit hook
+     * - Discovers skills when user mentions "skill"
+     */
+    UserPromptSubmit: async (
+      ctx: UserPromptSubmitContext,
+    ): Promise<UserPromptSubmitResult> => {
+      const injectedMessages: string[] = [];
+
+      // Skill discovery
+      if (mentionsSkill(ctx.prompt)) {
+        const skills = getSkills();
+        if (skills.length > 0) {
+          const skillList = skills
+            .map((s) =>
+              s.description ? `- ${s.name}: ${s.description}` : `- ${s.name}`,
+            )
+            .join("\n");
+
+          injectedMessages.push(`<skill-discovery>
+The user mentioned 'skill'. Available skills in this project:
+
+${skillList}
+
+If relevant to the user's request, read the SKILL.md file to load the skill instructions.
+</skill-discovery>`);
+        }
+      }
+
+      return {
+        block: false,
+        modifiedParts: ctx.parts,
+        messages: injectedMessages,
+      };
+    },
+  };
+}

--- a/.opencode/skills/git-worktrees/SKILL.md
+++ b/.opencode/skills/git-worktrees/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: git-worktrees
+description: Work with git worktrees for isolated parallel development. Use when starting feature work in isolation, when need separate workspace without branch switching, or when cleaning up worktrees after PR merge.
+---
+
+# Git Worktrees
+
+## Overview
+
+Git worktrees create isolated workspaces sharing the same repository, allowing
+work on multiple branches simultaneously without switching. Each worktree is a
+separate directory with its own working tree, but they share the same `.git`
+history.
+
+## When to Use Worktrees
+
+- **Parallel development**: Work on feature A while feature B builds/tests
+- **Code review**: Check out PR branch without disrupting current work
+- **Experiments**: Try something risky without affecting main workspace
+- **Long-running tasks**: Keep main branch available while feature develops
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| List worktrees | `git worktree list` |
+| Create worktree | `git worktree add <path> -b <branch>` |
+| Create from existing branch | `git worktree add <path> <branch>` |
+| Remove worktree | `git worktree remove <path>` |
+| Prune stale worktrees | `git worktree prune` |
+
+## Creating Worktrees
+
+### New Feature Branch
+
+```bash
+# Create worktree with new branch
+git worktree add .worktrees/my-feature -b feat/my-feature
+
+# Or specify base branch
+git worktree add .worktrees/my-feature -b feat/my-feature main
+```
+
+### From Existing Branch
+
+```bash
+# Check out existing remote branch
+git worktree add .worktrees/pr-review origin/fix-bug
+
+# Check out existing local branch
+git worktree add .worktrees/hotfix hotfix/urgent-fix
+```
+
+## Directory Structure
+
+```
+project/
+├── .git/                    # Shared git history
+├── .worktrees/              # Convention: keep worktrees here
+│   ├── feature-a/           # First worktree
+│   └── feature-b/           # Second worktree
+└── src/                     # Main worktree files
+```
+
+## Setup After Creating Worktree
+
+After creating a worktree, you typically need to:
+
+```bash
+cd .worktrees/my-feature
+
+# Install dependencies
+npm install  # or pnpm install, yarn, etc.
+
+# Copy any required env files
+cp ../.env .env.local
+
+# Verify setup
+npm test
+```
+
+## Safety Rules
+
+**NEVER remove a worktree with uncommitted changes without confirmation.**
+
+```bash
+# Check for uncommitted changes first
+git -C .worktrees/my-feature status --porcelain
+
+# If empty, safe to remove
+git worktree remove .worktrees/my-feature
+
+# Delete the branch after merge (-d is safe, fails if not merged)
+git branch -d feat/my-feature
+```
+
+### Removal Decision Matrix
+
+| PR Merged? | Uncommitted Changes? | Action |
+|------------|---------------------|--------|
+| Yes | No | Safe to remove |
+| Yes | Yes | Ask user - changes will be lost |
+| No | No | Do NOT remove - work not preserved |
+| No | Yes | Do NOT remove - active work |
+
+## Cleaning Up Worktrees
+
+### Manual Cleanup
+
+```bash
+# 1. Check if work is merged (if using GitHub)
+gh pr list --head feat/my-feature --state merged
+
+# 2. Check for uncommitted changes
+git -C .worktrees/my-feature status --porcelain
+
+# 3. Remove worktree (only if merged or confirmed with user)
+git worktree remove .worktrees/my-feature
+
+# 4. Delete branch
+git branch -d feat/my-feature
+```
+
+### Prune Stale Worktrees
+
+If a worktree directory was deleted manually:
+
+```bash
+git worktree prune
+```
+
+## Common Patterns
+
+### Review a PR
+
+```bash
+# Create worktree from PR branch
+git fetch origin pull/123/head:pr-123
+git worktree add .worktrees/pr-123 pr-123
+
+# Review, test, then clean up
+git worktree remove .worktrees/pr-123
+git branch -D pr-123
+```
+
+### Parallel Feature Development
+
+```bash
+# Main work continues in project root
+# Start new feature in worktree
+git worktree add .worktrees/new-api -b feat/new-api
+
+# Work on both simultaneously
+code .worktrees/new-api  # Opens new VS Code window
+```
+
+## Troubleshooting
+
+### "Branch already checked out"
+
+A branch can only be checked out in one worktree at a time:
+
+```bash
+# Find where branch is checked out
+git worktree list
+
+# Remove that worktree first, or use different branch
+```
+
+### "Worktree directory not empty"
+
+```bash
+# Force add if directory exists but isn't a worktree
+git worktree add --force <path> <branch>
+```
+
+### Locked Worktree
+
+If a worktree is locked (prevents accidental removal):
+
+```bash
+# Unlock it
+git worktree unlock <path>
+
+# Then remove
+git worktree remove <path>
+```

--- a/.opencode/skills/json-canvas/SKILL.md
+++ b/.opencode/skills/json-canvas/SKILL.md
@@ -1,0 +1,642 @@
+---
+name: json-canvas
+description: Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections. Use when working with .canvas files, creating visual canvases, mind maps, flowcharts, or when the user mentions Canvas files in Obsidian.
+---
+
+# JSON Canvas Skill
+
+This skill enables skills-compatible agents to create and edit valid JSON Canvas files (`.canvas`) used in Obsidian and other applications.
+
+## Overview
+
+JSON Canvas is an open file format for infinite canvas data. Canvas files use the `.canvas` extension and contain valid JSON following the [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/).
+
+## File Structure
+
+A canvas file contains two top-level arrays:
+
+```json
+{
+  "nodes": [],
+  "edges": []
+}
+```
+
+- `nodes` (optional): Array of node objects
+- `edges` (optional): Array of edge objects connecting nodes
+
+## Nodes
+
+Nodes are objects placed on the canvas. There are four node types:
+- `text` - Text content with Markdown
+- `file` - Reference to files/attachments
+- `link` - External URL
+- `group` - Visual container for other nodes
+
+### Z-Index Ordering
+
+Nodes are ordered by z-index in the array:
+- First node = bottom layer (displayed below others)
+- Last node = top layer (displayed above others)
+
+### Generic Node Attributes
+
+All nodes share these attributes:
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `id` | Yes | string | Unique identifier for the node |
+| `type` | Yes | string | Node type: `text`, `file`, `link`, or `group` |
+| `x` | Yes | integer | X position in pixels |
+| `y` | Yes | integer | Y position in pixels |
+| `width` | Yes | integer | Width in pixels |
+| `height` | Yes | integer | Height in pixels |
+| `color` | No | canvasColor | Node color (see Color section) |
+
+### Text Nodes
+
+Text nodes contain Markdown content.
+
+```json
+{
+  "id": "6f0ad84f44ce9c17",
+  "type": "text",
+  "x": 0,
+  "y": 0,
+  "width": 400,
+  "height": 200,
+  "text": "# Hello World\n\nThis is **Markdown** content."
+}
+```
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `text` | Yes | string | Plain text with Markdown syntax |
+
+### File Nodes
+
+File nodes reference files or attachments (images, videos, PDFs, notes, etc.).
+
+```json
+{
+  "id": "a1b2c3d4e5f67890",
+  "type": "file",
+  "x": 500,
+  "y": 0,
+  "width": 400,
+  "height": 300,
+  "file": "Attachments/diagram.png"
+}
+```
+
+```json
+{
+  "id": "b2c3d4e5f6789012",
+  "type": "file",
+  "x": 500,
+  "y": 400,
+  "width": 400,
+  "height": 300,
+  "file": "Notes/Project Overview.md",
+  "subpath": "#Implementation"
+}
+```
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `file` | Yes | string | Path to file within the system |
+| `subpath` | No | string | Link to heading or block (starts with `#`) |
+
+### Link Nodes
+
+Link nodes display external URLs.
+
+```json
+{
+  "id": "c3d4e5f678901234",
+  "type": "link",
+  "x": 1000,
+  "y": 0,
+  "width": 400,
+  "height": 200,
+  "url": "https://obsidian.md"
+}
+```
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `url` | Yes | string | External URL |
+
+### Group Nodes
+
+Group nodes are visual containers for organizing other nodes.
+
+```json
+{
+  "id": "d4e5f6789012345a",
+  "type": "group",
+  "x": -50,
+  "y": -50,
+  "width": 1000,
+  "height": 600,
+  "label": "Project Overview",
+  "color": "4"
+}
+```
+
+```json
+{
+  "id": "e5f67890123456ab",
+  "type": "group",
+  "x": 0,
+  "y": 700,
+  "width": 800,
+  "height": 500,
+  "label": "Resources",
+  "background": "Attachments/background.png",
+  "backgroundStyle": "cover"
+}
+```
+
+| Attribute | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `label` | No | string | Text label for the group |
+| `background` | No | string | Path to background image |
+| `backgroundStyle` | No | string | Background rendering style |
+
+#### Background Styles
+
+| Value | Description |
+|-------|-------------|
+| `cover` | Fills entire width and height of node |
+| `ratio` | Maintains aspect ratio of background image |
+| `repeat` | Repeats image as pattern in both directions |
+
+## Edges
+
+Edges are lines connecting nodes.
+
+```json
+{
+  "id": "f67890123456789a",
+  "fromNode": "6f0ad84f44ce9c17",
+  "toNode": "a1b2c3d4e5f67890"
+}
+```
+
+```json
+{
+  "id": "0123456789abcdef",
+  "fromNode": "6f0ad84f44ce9c17",
+  "fromSide": "right",
+  "fromEnd": "none",
+  "toNode": "b2c3d4e5f6789012",
+  "toSide": "left",
+  "toEnd": "arrow",
+  "color": "1",
+  "label": "leads to"
+}
+```
+
+| Attribute | Required | Type | Default | Description |
+|-----------|----------|------|---------|-------------|
+| `id` | Yes | string | - | Unique identifier for the edge |
+| `fromNode` | Yes | string | - | Node ID where connection starts |
+| `fromSide` | No | string | - | Side where edge starts |
+| `fromEnd` | No | string | `none` | Shape at edge start |
+| `toNode` | Yes | string | - | Node ID where connection ends |
+| `toSide` | No | string | - | Side where edge ends |
+| `toEnd` | No | string | `arrow` | Shape at edge end |
+| `color` | No | canvasColor | - | Line color |
+| `label` | No | string | - | Text label for the edge |
+
+### Side Values
+
+| Value | Description |
+|-------|-------------|
+| `top` | Top edge of node |
+| `right` | Right edge of node |
+| `bottom` | Bottom edge of node |
+| `left` | Left edge of node |
+
+### End Shapes
+
+| Value | Description |
+|-------|-------------|
+| `none` | No endpoint shape |
+| `arrow` | Arrow endpoint |
+
+## Colors
+
+The `canvasColor` type can be specified in two ways:
+
+### Hex Colors
+
+```json
+{
+  "color": "#FF0000"
+}
+```
+
+### Preset Colors
+
+```json
+{
+  "color": "1"
+}
+```
+
+| Preset | Color |
+|--------|-------|
+| `"1"` | Red |
+| `"2"` | Orange |
+| `"3"` | Yellow |
+| `"4"` | Green |
+| `"5"` | Cyan |
+| `"6"` | Purple |
+
+Note: Specific color values for presets are intentionally undefined, allowing applications to use their own brand colors.
+
+## Complete Examples
+
+### Simple Canvas with Text and Connections
+
+```json
+{
+  "nodes": [
+    {
+      "id": "8a9b0c1d2e3f4a5b",
+      "type": "text",
+      "x": 0,
+      "y": 0,
+      "width": 300,
+      "height": 150,
+      "text": "# Main Idea\n\nThis is the central concept."
+    },
+    {
+      "id": "1a2b3c4d5e6f7a8b",
+      "type": "text",
+      "x": 400,
+      "y": -100,
+      "width": 250,
+      "height": 100,
+      "text": "## Supporting Point A\n\nDetails here."
+    },
+    {
+      "id": "2b3c4d5e6f7a8b9c",
+      "type": "text",
+      "x": 400,
+      "y": 100,
+      "width": 250,
+      "height": 100,
+      "text": "## Supporting Point B\n\nMore details."
+    }
+  ],
+  "edges": [
+    {
+      "id": "3c4d5e6f7a8b9c0d",
+      "fromNode": "8a9b0c1d2e3f4a5b",
+      "fromSide": "right",
+      "toNode": "1a2b3c4d5e6f7a8b",
+      "toSide": "left"
+    },
+    {
+      "id": "4d5e6f7a8b9c0d1e",
+      "fromNode": "8a9b0c1d2e3f4a5b",
+      "fromSide": "right",
+      "toNode": "2b3c4d5e6f7a8b9c",
+      "toSide": "left"
+    }
+  ]
+}
+```
+
+### Project Board with Groups
+
+```json
+{
+  "nodes": [
+    {
+      "id": "5e6f7a8b9c0d1e2f",
+      "type": "group",
+      "x": 0,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "To Do",
+      "color": "1"
+    },
+    {
+      "id": "6f7a8b9c0d1e2f3a",
+      "type": "group",
+      "x": 350,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "In Progress",
+      "color": "3"
+    },
+    {
+      "id": "7a8b9c0d1e2f3a4b",
+      "type": "group",
+      "x": 700,
+      "y": 0,
+      "width": 300,
+      "height": 500,
+      "label": "Done",
+      "color": "4"
+    },
+    {
+      "id": "8b9c0d1e2f3a4b5c",
+      "type": "text",
+      "x": 20,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 1\n\nImplement feature X"
+    },
+    {
+      "id": "9c0d1e2f3a4b5c6d",
+      "type": "text",
+      "x": 370,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 2\n\nReview PR #123",
+      "color": "2"
+    },
+    {
+      "id": "0d1e2f3a4b5c6d7e",
+      "type": "text",
+      "x": 720,
+      "y": 50,
+      "width": 260,
+      "height": 80,
+      "text": "## Task 3\n\n~~Setup CI/CD~~"
+    }
+  ],
+  "edges": []
+}
+```
+
+### Research Canvas with Files and Links
+
+```json
+{
+  "nodes": [
+    {
+      "id": "1e2f3a4b5c6d7e8f",
+      "type": "text",
+      "x": 300,
+      "y": 200,
+      "width": 400,
+      "height": 200,
+      "text": "# Research Topic\n\n## Key Questions\n\n- How does X affect Y?\n- What are the implications?",
+      "color": "5"
+    },
+    {
+      "id": "2f3a4b5c6d7e8f9a",
+      "type": "file",
+      "x": 0,
+      "y": 0,
+      "width": 250,
+      "height": 150,
+      "file": "Literature/Paper A.pdf"
+    },
+    {
+      "id": "3a4b5c6d7e8f9a0b",
+      "type": "file",
+      "x": 0,
+      "y": 200,
+      "width": 250,
+      "height": 150,
+      "file": "Notes/Meeting Notes.md",
+      "subpath": "#Key Insights"
+    },
+    {
+      "id": "4b5c6d7e8f9a0b1c",
+      "type": "link",
+      "x": 0,
+      "y": 400,
+      "width": 250,
+      "height": 100,
+      "url": "https://example.com/research"
+    },
+    {
+      "id": "5c6d7e8f9a0b1c2d",
+      "type": "file",
+      "x": 750,
+      "y": 150,
+      "width": 300,
+      "height": 250,
+      "file": "Attachments/diagram.png"
+    }
+  ],
+  "edges": [
+    {
+      "id": "6d7e8f9a0b1c2d3e",
+      "fromNode": "2f3a4b5c6d7e8f9a",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "label": "supports"
+    },
+    {
+      "id": "7e8f9a0b1c2d3e4f",
+      "fromNode": "3a4b5c6d7e8f9a0b",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "label": "informs"
+    },
+    {
+      "id": "8f9a0b1c2d3e4f5a",
+      "fromNode": "4b5c6d7e8f9a0b1c",
+      "fromSide": "right",
+      "toNode": "1e2f3a4b5c6d7e8f",
+      "toSide": "left",
+      "toEnd": "arrow",
+      "color": "6"
+    },
+    {
+      "id": "9a0b1c2d3e4f5a6b",
+      "fromNode": "1e2f3a4b5c6d7e8f",
+      "fromSide": "right",
+      "toNode": "5c6d7e8f9a0b1c2d",
+      "toSide": "left",
+      "label": "visualized by"
+    }
+  ]
+}
+```
+
+### Flowchart
+
+```json
+{
+  "nodes": [
+    {
+      "id": "a0b1c2d3e4f5a6b7",
+      "type": "text",
+      "x": 200,
+      "y": 0,
+      "width": 150,
+      "height": 60,
+      "text": "**Start**",
+      "color": "4"
+    },
+    {
+      "id": "b1c2d3e4f5a6b7c8",
+      "type": "text",
+      "x": 200,
+      "y": 100,
+      "width": 150,
+      "height": 60,
+      "text": "Step 1:\nGather data"
+    },
+    {
+      "id": "c2d3e4f5a6b7c8d9",
+      "type": "text",
+      "x": 200,
+      "y": 200,
+      "width": 150,
+      "height": 80,
+      "text": "**Decision**\n\nIs data valid?",
+      "color": "3"
+    },
+    {
+      "id": "d3e4f5a6b7c8d9e0",
+      "type": "text",
+      "x": 400,
+      "y": 200,
+      "width": 150,
+      "height": 60,
+      "text": "Process data"
+    },
+    {
+      "id": "e4f5a6b7c8d9e0f1",
+      "type": "text",
+      "x": 0,
+      "y": 200,
+      "width": 150,
+      "height": 60,
+      "text": "Request new data",
+      "color": "1"
+    },
+    {
+      "id": "f5a6b7c8d9e0f1a2",
+      "type": "text",
+      "x": 400,
+      "y": 320,
+      "width": 150,
+      "height": 60,
+      "text": "**End**",
+      "color": "4"
+    }
+  ],
+  "edges": [
+    {
+      "id": "a6b7c8d9e0f1a2b3",
+      "fromNode": "a0b1c2d3e4f5a6b7",
+      "fromSide": "bottom",
+      "toNode": "b1c2d3e4f5a6b7c8",
+      "toSide": "top"
+    },
+    {
+      "id": "b7c8d9e0f1a2b3c4",
+      "fromNode": "b1c2d3e4f5a6b7c8",
+      "fromSide": "bottom",
+      "toNode": "c2d3e4f5a6b7c8d9",
+      "toSide": "top"
+    },
+    {
+      "id": "c8d9e0f1a2b3c4d5",
+      "fromNode": "c2d3e4f5a6b7c8d9",
+      "fromSide": "right",
+      "toNode": "d3e4f5a6b7c8d9e0",
+      "toSide": "left",
+      "label": "Yes",
+      "color": "4"
+    },
+    {
+      "id": "d9e0f1a2b3c4d5e6",
+      "fromNode": "c2d3e4f5a6b7c8d9",
+      "fromSide": "left",
+      "toNode": "e4f5a6b7c8d9e0f1",
+      "toSide": "right",
+      "label": "No",
+      "color": "1"
+    },
+    {
+      "id": "e0f1a2b3c4d5e6f7",
+      "fromNode": "e4f5a6b7c8d9e0f1",
+      "fromSide": "top",
+      "fromEnd": "none",
+      "toNode": "b1c2d3e4f5a6b7c8",
+      "toSide": "left",
+      "toEnd": "arrow"
+    },
+    {
+      "id": "f1a2b3c4d5e6f7a8",
+      "fromNode": "d3e4f5a6b7c8d9e0",
+      "fromSide": "bottom",
+      "toNode": "f5a6b7c8d9e0f1a2",
+      "toSide": "top"
+    }
+  ]
+}
+```
+
+## ID Generation
+
+Node and edge IDs must be unique strings. Obsidian generates 16-character hexadecimal IDs:
+
+```json
+"id": "6f0ad84f44ce9c17"
+"id": "a3b2c1d0e9f8g7h6"
+"id": "1234567890abcdef"
+```
+
+This format is a 16-character lowercase hex string (64-bit random value).
+
+## Layout Guidelines
+
+### Positioning
+
+- Coordinates can be negative (canvas extends infinitely)
+- `x` increases to the right
+- `y` increases downward
+- Position refers to top-left corner of node
+
+### Recommended Sizes
+
+| Node Type | Suggested Width | Suggested Height |
+|-----------|-----------------|------------------|
+| Small text | 200-300 | 80-150 |
+| Medium text | 300-450 | 150-300 |
+| Large text | 400-600 | 300-500 |
+| File preview | 300-500 | 200-400 |
+| Link preview | 250-400 | 100-200 |
+| Group | Varies | Varies |
+
+### Spacing
+
+- Leave 20-50px padding inside groups
+- Space nodes 50-100px apart for readability
+- Align nodes to grid (multiples of 10 or 20) for cleaner layouts
+
+## Validation Rules
+
+1. All `id` values must be unique across nodes and edges
+2. `fromNode` and `toNode` must reference existing node IDs
+3. Required fields must be present for each node type
+4. `type` must be one of: `text`, `file`, `link`, `group`
+5. `backgroundStyle` must be one of: `cover`, `ratio`, `repeat`
+6. `fromSide`, `toSide` must be one of: `top`, `right`, `bottom`, `left`
+7. `fromEnd`, `toEnd` must be one of: `none`, `arrow`
+8. Color presets must be `"1"` through `"6"` or valid hex color
+
+## References
+
+- [JSON Canvas Spec 1.0](https://jsoncanvas.org/spec/1.0/)
+- [JSON Canvas GitHub](https://github.com/obsidianmd/jsoncanvas)

--- a/.opencode/skills/obsidian-bases/SKILL.md
+++ b/.opencode/skills/obsidian-bases/SKILL.md
@@ -1,0 +1,618 @@
+---
+name: obsidian-bases
+description: Create and edit Obsidian Bases (.base files) with views, filters, formulas, and summaries. Use when working with .base files, creating database-like views of notes, or when the user mentions Bases, table views, card views, filters, or formulas in Obsidian.
+---
+
+# Obsidian Bases Skill
+
+This skill enables skills-compatible agents to create and edit valid Obsidian Bases (`.base` files) including views, filters, formulas, and all related configurations.
+
+## Overview
+
+Obsidian Bases are YAML-based files that define dynamic views of notes in an Obsidian vault. A Base file can contain multiple views, global filters, formulas, property configurations, and custom summaries.
+
+## File Format
+
+Base files use the `.base` extension and contain valid YAML. They can also be embedded in Markdown code blocks.
+
+## Complete Schema
+
+```yaml
+# Global filters apply to ALL views in the base
+filters:
+  # Can be a single filter string
+  # OR a recursive filter object with and/or/not
+  and: []
+  or: []
+  not: []
+
+# Define formula properties that can be used across all views
+formulas:
+  formula_name: 'expression'
+
+# Configure display names and settings for properties
+properties:
+  property_name:
+    displayName: "Display Name"
+  formula.formula_name:
+    displayName: "Formula Display Name"
+  file.ext:
+    displayName: "Extension"
+
+# Define custom summary formulas
+summaries:
+  custom_summary_name: 'values.mean().round(3)'
+
+# Define one or more views
+views:
+  - type: table | cards | list | map
+    name: "View Name"
+    limit: 10                    # Optional: limit results
+    groupBy:                     # Optional: group results
+      property: property_name
+      direction: ASC | DESC
+    filters:                     # View-specific filters
+      and: []
+    order:                       # Properties to display in order
+      - file.name
+      - property_name
+      - formula.formula_name
+    summaries:                   # Map properties to summary formulas
+      property_name: Average
+```
+
+## Filter Syntax
+
+Filters narrow down results. They can be applied globally or per-view.
+
+### Filter Structure
+
+```yaml
+# Single filter
+filters: 'status == "done"'
+
+# AND - all conditions must be true
+filters:
+  and:
+    - 'status == "done"'
+    - 'priority > 3'
+
+# OR - any condition can be true
+filters:
+  or:
+    - 'file.hasTag("book")'
+    - 'file.hasTag("article")'
+
+# NOT - exclude matching items
+filters:
+  not:
+    - 'file.hasTag("archived")'
+
+# Nested filters
+filters:
+  or:
+    - file.hasTag("tag")
+    - and:
+        - file.hasTag("book")
+        - file.hasLink("Textbook")
+    - not:
+        - file.hasTag("book")
+        - file.inFolder("Required Reading")
+```
+
+### Filter Operators
+
+| Operator | Description |
+|----------|-------------|
+| `==` | equals |
+| `!=` | not equal |
+| `>` | greater than |
+| `<` | less than |
+| `>=` | greater than or equal |
+| `<=` | less than or equal |
+| `&&` | logical and |
+| `\|\|` | logical or |
+| <code>!</code> | logical not |
+
+## Properties
+
+### Three Types of Properties
+
+1. **Note properties** - From frontmatter: `note.author` or just `author`
+2. **File properties** - File metadata: `file.name`, `file.mtime`, etc.
+3. **Formula properties** - Computed values: `formula.my_formula`
+
+### File Properties Reference
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `file.name` | String | File name |
+| `file.basename` | String | File name without extension |
+| `file.path` | String | Full path to file |
+| `file.folder` | String | Parent folder path |
+| `file.ext` | String | File extension |
+| `file.size` | Number | File size in bytes |
+| `file.ctime` | Date | Created time |
+| `file.mtime` | Date | Modified time |
+| `file.tags` | List | All tags in file |
+| `file.links` | List | Internal links in file |
+| `file.backlinks` | List | Files linking to this file |
+| `file.embeds` | List | Embeds in the note |
+| `file.properties` | Object | All frontmatter properties |
+
+### The `this` Keyword
+
+- In main content area: refers to the base file itself
+- When embedded: refers to the embedding file
+- In sidebar: refers to the active file in main content
+
+## Formula Syntax
+
+Formulas compute values from properties. Defined in the `formulas` section.
+
+```yaml
+formulas:
+  # Simple arithmetic
+  total: "price * quantity"
+  
+  # Conditional logic
+  status_icon: 'if(done, "✅", "⏳")'
+  
+  # String formatting
+  formatted_price: 'if(price, price.toFixed(2) + " dollars")'
+  
+  # Date formatting
+  created: 'file.ctime.format("YYYY-MM-DD")'
+  
+  # Complex expressions
+  days_old: '((now() - file.ctime) / 86400000).round(0)'
+```
+
+## Functions Reference
+
+### Global Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date(string): date` | Parse string to date. Format: `YYYY-MM-DD HH:mm:ss` |
+| `duration()` | `duration(string): duration` | Parse duration string |
+| `now()` | `now(): date` | Current date and time |
+| `today()` | `today(): date` | Current date (time = 00:00:00) |
+| `if()` | `if(condition, trueResult, falseResult?)` | Conditional |
+| `min()` | `min(n1, n2, ...): number` | Smallest number |
+| `max()` | `max(n1, n2, ...): number` | Largest number |
+| `number()` | `number(any): number` | Convert to number |
+| `link()` | `link(path, display?): Link` | Create a link |
+| `list()` | `list(element): List` | Wrap in list if not already |
+| `file()` | `file(path): file` | Get file object |
+| `image()` | `image(path): image` | Create image for rendering |
+| `icon()` | `icon(name): icon` | Lucide icon by name |
+| `html()` | `html(string): html` | Render as HTML |
+| `escapeHTML()` | `escapeHTML(string): string` | Escape HTML characters |
+
+### Any Type Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `isTruthy()` | `any.isTruthy(): boolean` | Coerce to boolean |
+| `isType()` | `any.isType(type): boolean` | Check type |
+| `toString()` | `any.toString(): string` | Convert to string |
+
+### Date Functions & Fields
+
+**Fields:** `date.year`, `date.month`, `date.day`, `date.hour`, `date.minute`, `date.second`, `date.millisecond`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date.date(): date` | Remove time portion |
+| `format()` | `date.format(string): string` | Format with Moment.js pattern |
+| `time()` | `date.time(): string` | Get time as string |
+| `relative()` | `date.relative(): string` | Human-readable relative time |
+| `isEmpty()` | `date.isEmpty(): boolean` | Always false for dates |
+
+### Date Arithmetic
+
+```yaml
+# Duration units: y/year/years, M/month/months, d/day/days, 
+#                 w/week/weeks, h/hour/hours, m/minute/minutes, s/second/seconds
+
+# Add/subtract durations
+"date + \"1M\""           # Add 1 month
+"date - \"2h\""           # Subtract 2 hours
+"now() + \"1 day\""       # Tomorrow
+"today() + \"7d\""        # A week from today
+
+# Subtract dates for millisecond difference
+"now() - file.ctime"
+
+# Complex duration arithmetic
+"now() + (duration('1d') * 2)"
+```
+
+### String Functions
+
+**Field:** `string.length`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `contains()` | `string.contains(value): boolean` | Check substring |
+| `containsAll()` | `string.containsAll(...values): boolean` | All substrings present |
+| `containsAny()` | `string.containsAny(...values): boolean` | Any substring present |
+| `startsWith()` | `string.startsWith(query): boolean` | Starts with query |
+| `endsWith()` | `string.endsWith(query): boolean` | Ends with query |
+| `isEmpty()` | `string.isEmpty(): boolean` | Empty or not present |
+| `lower()` | `string.lower(): string` | To lowercase |
+| `title()` | `string.title(): string` | To Title Case |
+| `trim()` | `string.trim(): string` | Remove whitespace |
+| `replace()` | `string.replace(pattern, replacement): string` | Replace pattern |
+| `repeat()` | `string.repeat(count): string` | Repeat string |
+| `reverse()` | `string.reverse(): string` | Reverse string |
+| `slice()` | `string.slice(start, end?): string` | Substring |
+| `split()` | `string.split(separator, n?): list` | Split to list |
+
+### Number Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `abs()` | `number.abs(): number` | Absolute value |
+| `ceil()` | `number.ceil(): number` | Round up |
+| `floor()` | `number.floor(): number` | Round down |
+| `round()` | `number.round(digits?): number` | Round to digits |
+| `toFixed()` | `number.toFixed(precision): string` | Fixed-point notation |
+| `isEmpty()` | `number.isEmpty(): boolean` | Not present |
+
+### List Functions
+
+**Field:** `list.length`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `contains()` | `list.contains(value): boolean` | Element exists |
+| `containsAll()` | `list.containsAll(...values): boolean` | All elements exist |
+| `containsAny()` | `list.containsAny(...values): boolean` | Any element exists |
+| `filter()` | `list.filter(expression): list` | Filter by condition (uses `value`, `index`) |
+| `map()` | `list.map(expression): list` | Transform elements (uses `value`, `index`) |
+| `reduce()` | `list.reduce(expression, initial): any` | Reduce to single value (uses `value`, `index`, `acc`) |
+| `flat()` | `list.flat(): list` | Flatten nested lists |
+| `join()` | `list.join(separator): string` | Join to string |
+| `reverse()` | `list.reverse(): list` | Reverse order |
+| `slice()` | `list.slice(start, end?): list` | Sublist |
+| `sort()` | `list.sort(): list` | Sort ascending |
+| `unique()` | `list.unique(): list` | Remove duplicates |
+| `isEmpty()` | `list.isEmpty(): boolean` | No elements |
+
+### File Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `asLink()` | `file.asLink(display?): Link` | Convert to link |
+| `hasLink()` | `file.hasLink(otherFile): boolean` | Has link to file |
+| `hasTag()` | `file.hasTag(...tags): boolean` | Has any of the tags |
+| `hasProperty()` | `file.hasProperty(name): boolean` | Has property |
+| `inFolder()` | `file.inFolder(folder): boolean` | In folder or subfolder |
+
+### Link Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `asFile()` | `link.asFile(): file` | Get file object |
+| `linksTo()` | `link.linksTo(file): boolean` | Links to file |
+
+### Object Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `isEmpty()` | `object.isEmpty(): boolean` | No properties |
+| `keys()` | `object.keys(): list` | List of keys |
+| `values()` | `object.values(): list` | List of values |
+
+### Regular Expression Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `matches()` | `regexp.matches(string): boolean` | Test if matches |
+
+## View Types
+
+### Table View
+
+```yaml
+views:
+  - type: table
+    name: "My Table"
+    order:
+      - file.name
+      - status
+      - due_date
+    summaries:
+      price: Sum
+      count: Average
+```
+
+### Cards View
+
+```yaml
+views:
+  - type: cards
+    name: "Gallery"
+    order:
+      - file.name
+      - cover_image
+      - description
+```
+
+### List View
+
+```yaml
+views:
+  - type: list
+    name: "Simple List"
+    order:
+      - file.name
+      - status
+```
+
+### Map View
+
+Requires latitude/longitude properties and the Maps community plugin.
+
+```yaml
+views:
+  - type: map
+    name: "Locations"
+    # Map-specific settings for lat/lng properties
+```
+
+## Default Summary Formulas
+
+| Name | Input Type | Description |
+|------|------------|-------------|
+| `Average` | Number | Mathematical mean |
+| `Min` | Number | Smallest number |
+| `Max` | Number | Largest number |
+| `Sum` | Number | Sum of all numbers |
+| `Range` | Number | Max - Min |
+| `Median` | Number | Mathematical median |
+| `Stddev` | Number | Standard deviation |
+| `Earliest` | Date | Earliest date |
+| `Latest` | Date | Latest date |
+| `Range` | Date | Latest - Earliest |
+| `Checked` | Boolean | Count of true values |
+| `Unchecked` | Boolean | Count of false values |
+| `Empty` | Any | Count of empty values |
+| `Filled` | Any | Count of non-empty values |
+| `Unique` | Any | Count of unique values |
+
+## Complete Examples
+
+### Task Tracker Base
+
+```yaml
+filters:
+  and:
+    - file.hasTag("task")
+    - 'file.ext == "md"'
+
+formulas:
+  days_until_due: 'if(due, ((date(due) - today()) / 86400000).round(0), "")'
+  is_overdue: 'if(due, date(due) < today() && status != "done", false)'
+  priority_label: 'if(priority == 1, "🔴 High", if(priority == 2, "🟡 Medium", "🟢 Low"))'
+
+properties:
+  status:
+    displayName: Status
+  formula.days_until_due:
+    displayName: "Days Until Due"
+  formula.priority_label:
+    displayName: Priority
+
+views:
+  - type: table
+    name: "Active Tasks"
+    filters:
+      and:
+        - 'status != "done"'
+    order:
+      - file.name
+      - status
+      - formula.priority_label
+      - due
+      - formula.days_until_due
+    groupBy:
+      property: status
+      direction: ASC
+    summaries:
+      formula.days_until_due: Average
+
+  - type: table
+    name: "Completed"
+    filters:
+      and:
+        - 'status == "done"'
+    order:
+      - file.name
+      - completed_date
+```
+
+### Reading List Base
+
+```yaml
+filters:
+  or:
+    - file.hasTag("book")
+    - file.hasTag("article")
+
+formulas:
+  reading_time: 'if(pages, (pages * 2).toString() + " min", "")'
+  status_icon: 'if(status == "reading", "📖", if(status == "done", "✅", "📚"))'
+  year_read: 'if(finished_date, date(finished_date).year, "")'
+
+properties:
+  author:
+    displayName: Author
+  formula.status_icon:
+    displayName: ""
+  formula.reading_time:
+    displayName: "Est. Time"
+
+views:
+  - type: cards
+    name: "Library"
+    order:
+      - cover
+      - file.name
+      - author
+      - formula.status_icon
+    filters:
+      not:
+        - 'status == "dropped"'
+
+  - type: table
+    name: "Reading List"
+    filters:
+      and:
+        - 'status == "to-read"'
+    order:
+      - file.name
+      - author
+      - pages
+      - formula.reading_time
+```
+
+### Project Notes Base
+
+```yaml
+filters:
+  and:
+    - file.inFolder("Projects")
+    - 'file.ext == "md"'
+
+formulas:
+  last_updated: 'file.mtime.relative()'
+  link_count: 'file.links.length'
+  
+summaries:
+  avgLinks: 'values.filter(value.isType("number")).mean().round(1)'
+
+properties:
+  formula.last_updated:
+    displayName: "Updated"
+  formula.link_count:
+    displayName: "Links"
+
+views:
+  - type: table
+    name: "All Projects"
+    order:
+      - file.name
+      - status
+      - formula.last_updated
+      - formula.link_count
+    summaries:
+      formula.link_count: avgLinks
+    groupBy:
+      property: status
+      direction: ASC
+
+  - type: list
+    name: "Quick List"
+    order:
+      - file.name
+      - status
+```
+
+### Daily Notes Index
+
+```yaml
+filters:
+  and:
+    - file.inFolder("Daily Notes")
+    - '/^\d{4}-\d{2}-\d{2}$/.matches(file.basename)'
+
+formulas:
+  word_estimate: '(file.size / 5).round(0)'
+  day_of_week: 'date(file.basename).format("dddd")'
+
+properties:
+  formula.day_of_week:
+    displayName: "Day"
+  formula.word_estimate:
+    displayName: "~Words"
+
+views:
+  - type: table
+    name: "Recent Notes"
+    limit: 30
+    order:
+      - file.name
+      - formula.day_of_week
+      - formula.word_estimate
+      - file.mtime
+```
+
+## Embedding Bases
+
+Embed in Markdown files:
+
+```markdown
+![[MyBase.base]]
+
+<!-- Specific view -->
+![[MyBase.base#View Name]]
+```
+
+## YAML Quoting Rules
+
+- Use single quotes for formulas containing double quotes: `'if(done, "Yes", "No")'`
+- Use double quotes for simple strings: `"My View Name"`
+- Escape nested quotes properly in complex expressions
+
+## Common Patterns
+
+### Filter by Tag
+```yaml
+filters:
+  and:
+    - file.hasTag("project")
+```
+
+### Filter by Folder
+```yaml
+filters:
+  and:
+    - file.inFolder("Notes")
+```
+
+### Filter by Date Range
+```yaml
+filters:
+  and:
+    - 'file.mtime > now() - "7d"'
+```
+
+### Filter by Property Value
+```yaml
+filters:
+  and:
+    - 'status == "active"'
+    - 'priority >= 3'
+```
+
+### Combine Multiple Conditions
+```yaml
+filters:
+  or:
+    - and:
+        - file.hasTag("important")
+        - 'status != "done"'
+    - and:
+        - 'priority == 1'
+        - 'due != ""'
+```
+
+## References
+
+- [Bases Syntax](https://help.obsidian.md/bases/syntax)
+- [Functions](https://help.obsidian.md/bases/functions)
+- [Views](https://help.obsidian.md/bases/views)
+- [Formulas](https://help.obsidian.md/formulas)

--- a/.opencode/skills/obsidian-markdown/SKILL.md
+++ b/.opencode/skills/obsidian-markdown/SKILL.md
@@ -1,0 +1,620 @@
+---
+name: obsidian-markdown
+description: Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific syntax. Use when working with .md files in Obsidian, or when the user mentions wikilinks, callouts, frontmatter, tags, embeds, or Obsidian notes.
+---
+
+# Obsidian Flavored Markdown Skill
+
+This skill enables skills-compatible agents to create and edit valid Obsidian Flavored Markdown, including all Obsidian-specific syntax extensions.
+
+## Overview
+
+Obsidian uses a combination of Markdown flavors:
+- [CommonMark](https://commonmark.org/)
+- [GitHub Flavored Markdown](https://github.github.com/gfm/)
+- [LaTeX](https://www.latex-project.org/) for math
+- Obsidian-specific extensions (wikilinks, callouts, embeds, etc.)
+
+## Basic Formatting
+
+### Paragraphs and Line Breaks
+
+```markdown
+This is a paragraph.
+
+This is another paragraph (blank line between creates separate paragraphs).
+
+For a line break within a paragraph, add two spaces at the end  
+or use Shift+Enter.
+```
+
+### Headings
+
+```markdown
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+```
+
+### Text Formatting
+
+| Style | Syntax | Example | Output |
+|-------|--------|---------|--------|
+| Bold | `**text**` or `__text__` | `**Bold**` | **Bold** |
+| Italic | `*text*` or `_text_` | `*Italic*` | *Italic* |
+| Bold + Italic | `***text***` | `***Both***` | ***Both*** |
+| Strikethrough | `~~text~~` | `~~Striked~~` | ~~Striked~~ |
+| Highlight | `==text==` | `==Highlighted==` | ==Highlighted== |
+| Inline code | `` `code` `` | `` `code` `` | `code` |
+
+### Escaping Formatting
+
+Use backslash to escape special characters:
+```markdown
+\*This won't be italic\*
+\#This won't be a heading
+1\. This won't be a list item
+```
+
+Common characters to escape: `\*`, `\_`, `\#`, `` \` ``, `\|`, `\~`
+
+## Internal Links (Wikilinks)
+
+### Basic Links
+
+```markdown
+[[Note Name]]
+[[Note Name.md]]
+[[Note Name|Display Text]]
+```
+
+### Link to Headings
+
+```markdown
+[[Note Name#Heading]]
+[[Note Name#Heading|Custom Text]]
+[[#Heading in same note]]
+[[##Search all headings in vault]]
+```
+
+### Link to Blocks
+
+```markdown
+[[Note Name#^block-id]]
+[[Note Name#^block-id|Custom Text]]
+```
+
+Define a block ID by adding `^block-id` at the end of a paragraph:
+```markdown
+This is a paragraph that can be linked to. ^my-block-id
+```
+
+For lists and quotes, add the block ID on a separate line:
+```markdown
+> This is a quote
+> With multiple lines
+
+^quote-id
+```
+
+### Search Links
+
+```markdown
+[[##heading]]     Search for headings containing "heading"
+[[^^block]]       Search for blocks containing "block"
+```
+
+## Markdown-Style Links
+
+```markdown
+[Display Text](Note%20Name.md)
+[Display Text](Note%20Name.md#Heading)
+[Display Text](https://example.com)
+[Note](obsidian://open?vault=VaultName&file=Note.md)
+```
+
+Note: Spaces must be URL-encoded as `%20` in Markdown links.
+
+## Embeds
+
+### Embed Notes
+
+```markdown
+![[Note Name]]
+![[Note Name#Heading]]
+![[Note Name#^block-id]]
+```
+
+### Embed Images
+
+```markdown
+![[image.png]]
+![[image.png|640x480]]    Width x Height
+![[image.png|300]]        Width only (maintains aspect ratio)
+```
+
+### External Images
+
+```markdown
+![Alt text](https://example.com/image.png)
+![Alt text|300](https://example.com/image.png)
+```
+
+### Embed Audio
+
+```markdown
+![[audio.mp3]]
+![[audio.ogg]]
+```
+
+### Embed PDF
+
+```markdown
+![[document.pdf]]
+![[document.pdf#page=3]]
+![[document.pdf#height=400]]
+```
+
+### Embed Lists
+
+```markdown
+![[Note#^list-id]]
+```
+
+Where the list has been defined with a block ID:
+```markdown
+- Item 1
+- Item 2
+- Item 3
+
+^list-id
+```
+
+### Embed Search Results
+
+````markdown
+```query
+tag:#project status:done
+```
+````
+
+## Callouts
+
+### Basic Callout
+
+```markdown
+> [!note]
+> This is a note callout.
+
+> [!info] Custom Title
+> This callout has a custom title.
+
+> [!tip] Title Only
+```
+
+### Foldable Callouts
+
+```markdown
+> [!faq]- Collapsed by default
+> This content is hidden until expanded.
+
+> [!faq]+ Expanded by default
+> This content is visible but can be collapsed.
+```
+
+### Nested Callouts
+
+```markdown
+> [!question] Outer callout
+> > [!note] Inner callout
+> > Nested content
+```
+
+### Supported Callout Types
+
+| Type | Aliases | Description |
+|------|---------|-------------|
+| `note` | - | Blue, pencil icon |
+| `abstract` | `summary`, `tldr` | Teal, clipboard icon |
+| `info` | - | Blue, info icon |
+| `todo` | - | Blue, checkbox icon |
+| `tip` | `hint`, `important` | Cyan, flame icon |
+| `success` | `check`, `done` | Green, checkmark icon |
+| `question` | `help`, `faq` | Yellow, question mark |
+| `warning` | `caution`, `attention` | Orange, warning icon |
+| `failure` | `fail`, `missing` | Red, X icon |
+| `danger` | `error` | Red, zap icon |
+| `bug` | - | Red, bug icon |
+| `example` | - | Purple, list icon |
+| `quote` | `cite` | Gray, quote icon |
+
+### Custom Callouts (CSS)
+
+```css
+.callout[data-callout="custom-type"] {
+  --callout-color: 255, 0, 0;
+  --callout-icon: lucide-alert-circle;
+}
+```
+
+## Lists
+
+### Unordered Lists
+
+```markdown
+- Item 1
+- Item 2
+  - Nested item
+  - Another nested
+- Item 3
+
+* Also works with asterisks
++ Or plus signs
+```
+
+### Ordered Lists
+
+```markdown
+1. First item
+2. Second item
+   1. Nested numbered
+   2. Another nested
+3. Third item
+
+1) Alternative syntax
+2) With parentheses
+```
+
+### Task Lists
+
+```markdown
+- [ ] Incomplete task
+- [x] Completed task
+- [ ] Task with sub-tasks
+  - [ ] Subtask 1
+  - [x] Subtask 2
+```
+
+## Quotes
+
+```markdown
+> This is a blockquote.
+> It can span multiple lines.
+>
+> And include multiple paragraphs.
+>
+> > Nested quotes work too.
+```
+
+## Code
+
+### Inline Code
+
+```markdown
+Use `backticks` for inline code.
+Use double backticks for ``code with a ` backtick inside``.
+```
+
+### Code Blocks
+
+````markdown
+```
+Plain code block
+```
+
+```javascript
+// Syntax highlighted code block
+function hello() {
+  console.log("Hello, world!");
+}
+```
+
+```python
+# Python example
+def greet(name):
+    print(f"Hello, {name}!")
+```
+````
+
+### Nesting Code Blocks
+
+Use more backticks or tildes for the outer block:
+
+`````markdown
+````markdown
+Here's how to create a code block:
+```js
+console.log("Hello")
+```
+````
+`````
+
+## Tables
+
+```markdown
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+```
+
+### Alignment
+
+```markdown
+| Left     | Center   | Right    |
+|:---------|:--------:|---------:|
+| Left     | Center   | Right    |
+```
+
+### Using Pipes in Tables
+
+Escape pipes with backslash:
+```markdown
+| Column 1 | Column 2 |
+|----------|----------|
+| [[Link\|Display]] | ![[Image\|100]] |
+```
+
+## Math (LaTeX)
+
+### Inline Math
+
+```markdown
+This is inline math: $e^{i\pi} + 1 = 0$
+```
+
+### Block Math
+
+```markdown
+$$
+\begin{vmatrix}
+a & b \\
+c & d
+\end{vmatrix} = ad - bc
+$$
+```
+
+### Common Math Syntax
+
+```markdown
+$x^2$              Superscript
+$x_i$              Subscript
+$\frac{a}{b}$      Fraction
+$\sqrt{x}$         Square root
+$\sum_{i=1}^{n}$   Summation
+$\int_a^b$         Integral
+$\alpha, \beta$    Greek letters
+```
+
+## Diagrams (Mermaid)
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Do this]
+    B -->|No| D[Do that]
+    C --> E[End]
+    D --> E
+```
+````
+
+### Sequence Diagrams
+
+````markdown
+```mermaid
+sequenceDiagram
+    Alice->>Bob: Hello Bob
+    Bob-->>Alice: Hi Alice
+```
+````
+
+### Linking in Diagrams
+
+````markdown
+```mermaid
+graph TD
+    A[Biology]
+    B[Chemistry]
+    A --> B
+    class A,B internal-link;
+```
+````
+
+## Footnotes
+
+```markdown
+This sentence has a footnote[^1].
+
+[^1]: This is the footnote content.
+
+You can also use named footnotes[^note].
+
+[^note]: Named footnotes still appear as numbers.
+
+Inline footnotes are also supported.^[This is an inline footnote.]
+```
+
+## Comments
+
+```markdown
+This is visible %%but this is hidden%% text.
+
+%%
+This entire block is hidden.
+It won't appear in reading view.
+%%
+```
+
+## Horizontal Rules
+
+```markdown
+---
+***
+___
+- - -
+* * *
+```
+
+## Properties (Frontmatter)
+
+Properties use YAML frontmatter at the start of a note:
+
+```yaml
+---
+title: My Note Title
+date: 2024-01-15
+tags:
+  - project
+  - important
+aliases:
+  - My Note
+  - Alternative Name
+cssclasses:
+  - custom-class
+status: in-progress
+rating: 4.5
+completed: false
+due: 2024-02-01T14:30:00
+---
+```
+
+### Property Types
+
+| Type | Example |
+|------|---------|
+| Text | `title: My Title` |
+| Number | `rating: 4.5` |
+| Checkbox | `completed: true` |
+| Date | `date: 2024-01-15` |
+| Date & Time | `due: 2024-01-15T14:30:00` |
+| List | `tags: [one, two]` or YAML list |
+| Links | `related: "[[Other Note]]"` |
+
+### Default Properties
+
+- `tags` - Note tags
+- `aliases` - Alternative names for the note
+- `cssclasses` - CSS classes applied to the note
+
+## Tags
+
+```markdown
+#tag
+#nested/tag
+#tag-with-dashes
+#tag_with_underscores
+
+In frontmatter:
+---
+tags:
+  - tag1
+  - nested/tag2
+---
+```
+
+Tags can contain:
+- Letters (any language)
+- Numbers (not as first character)
+- Underscores `_`
+- Hyphens `-`
+- Forward slashes `/` (for nesting)
+
+## HTML Content
+
+Obsidian supports HTML within Markdown:
+
+```markdown
+<div class="custom-container">
+  <span style="color: red;">Colored text</span>
+</div>
+
+<details>
+  <summary>Click to expand</summary>
+  Hidden content here.
+</details>
+
+<kbd>Ctrl</kbd> + <kbd>C</kbd>
+```
+
+## Complete Example
+
+````markdown
+---
+title: Project Alpha
+date: 2024-01-15
+tags:
+  - project
+  - active
+status: in-progress
+priority: high
+---
+
+# Project Alpha
+
+## Overview
+
+This project aims to [[improve workflow]] using modern techniques.
+
+> [!important] Key Deadline
+> The first milestone is due on ==January 30th==.
+
+## Tasks
+
+- [x] Initial planning
+- [x] Resource allocation
+- [ ] Development phase
+  - [ ] Backend implementation
+  - [ ] Frontend design
+- [ ] Testing
+- [ ] Deployment
+
+## Technical Notes
+
+The main algorithm uses the formula $O(n \log n)$ for sorting.
+
+```python
+def process_data(items):
+    return sorted(items, key=lambda x: x.priority)
+```
+
+## Architecture
+
+```mermaid
+graph LR
+    A[Input] --> B[Process]
+    B --> C[Output]
+    B --> D[Cache]
+```
+
+## Related Documents
+
+- ![[Meeting Notes 2024-01-10#Decisions]]
+- [[Budget Allocation|Budget]]
+- [[Team Members]]
+
+## References
+
+For more details, see the official documentation[^1].
+
+[^1]: https://example.com/docs
+
+%%
+Internal notes:
+- Review with team on Friday
+- Consider alternative approaches
+%%
+````
+
+## References
+
+- [Basic formatting syntax](https://help.obsidian.md/syntax)
+- [Advanced formatting syntax](https://help.obsidian.md/advanced-syntax)
+- [Obsidian Flavored Markdown](https://help.obsidian.md/obsidian-flavored-markdown)
+- [Internal links](https://help.obsidian.md/links)
+- [Embed files](https://help.obsidian.md/embeds)
+- [Callouts](https://help.obsidian.md/callouts)
+- [Properties](https://help.obsidian.md/properties)

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: skill-creator
+description: Guide for creating effective skills and commands. Use when users want to create a new skill or command, when updating an existing one, or when asking "how do I make a skill" or "create a command for X".
+---
+
+# Creating Skills and Commands
+
+This skill provides guidance for creating effective skills and commands in
+Claude Code projects.
+
+## Skills vs Commands
+
+| Aspect | Skills (`.claude/skills/`) | Commands (`.claude/commands/`) |
+|--------|---------------------------|-------------------------------|
+| Trigger | Auto-triggered by context | Explicit `/command` invocation |
+| Purpose | Background knowledge, domain expertise | Interactive workflows, multi-step tasks |
+| Example | Obsidian markdown syntax reference | `/daily-review` workflow |
+| Format | `SKILL.md` in named folder | `command-name.md` file |
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a public good. Skills share it with system prompts,
+conversation history, and the user's actual request.
+
+**Default assumption: Claude is already very smart.** Only add context Claude
+doesn't already have. Challenge each piece: "Does Claude really need this?"
+
+Prefer concise examples over verbose explanations.
+
+### Set Appropriate Degrees of Freedom
+
+Match specificity to the task's fragility:
+
+**High freedom (text instructions)**: Multiple approaches valid, context-dependent
+
+**Medium freedom (pseudocode/templates)**: Preferred pattern exists, some variation OK
+
+**Low freedom (specific scripts)**: Operations fragile, consistency critical
+
+## Skill Structure
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description - required)
+│   └── Markdown instructions
+└── Optional resources
+    ├── references/    # Documentation loaded as needed
+    ├── scripts/       # Executable code
+    └── assets/        # Templates, images, etc.
+```
+
+### SKILL.md Frontmatter
+
+```yaml
+---
+name: skill-name
+description:
+  What this skill does and when to use it. This is the PRIMARY trigger -
+  Claude reads this to decide when to load the skill. Include specific
+  scenarios and keywords that should activate it.
+---
+```
+
+**Important**: The description is loaded into context ALWAYS. The body is only
+loaded AFTER the skill triggers. Put "when to use" in the description, not the
+body.
+
+## Command Structure
+
+Commands are simpler - single markdown files:
+
+```
+.claude/commands/
+├── daily-review.md
+├── release.md
+└── new-command.md
+```
+
+### Command Frontmatter
+
+```yaml
+---
+name: command-name
+description: 'Brief description shown in /help'
+argument-hint: '[optional] [args]'
+allowed-tools: [Read, Glob, Bash(git:*)]  # Optional: restrict tools
+---
+```
+
+## Progressive Disclosure
+
+Use layered loading to manage context efficiently:
+
+1. **Metadata (name + description)** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<500 lines ideal)
+3. **References** - As needed by Claude (unlimited)
+
+### Pattern: Reference Files
+
+Keep SKILL.md lean, link to detailed references:
+
+```markdown
+# Skill Name
+
+## Quick Reference
+
+Basic usage here.
+
+## Detailed Guides
+
+- **Complex Topic A**: See `references/topic-a.md`
+- **Complex Topic B**: See `references/topic-b.md`
+```
+
+Claude reads reference files only when needed.
+
+## Creating a New Skill
+
+### Step 1: Understand the Use Case
+
+Ask:
+- "What functionality should this skill support?"
+- "What would trigger someone to need this?"
+- "What does Claude NOT already know that this should teach?"
+
+### Step 2: Plan the Contents
+
+Analyze concrete examples:
+- What code/scripts get rewritten each time?
+- What documentation would help?
+- What assets (templates, examples) are needed?
+
+### Step 3: Create the Skill
+
+```bash
+mkdir -p .claude/skills/my-skill
+```
+
+Write `SKILL.md`:
+
+```yaml
+---
+name: my-skill
+description:
+  What it does. When to use it. Keywords that trigger it.
+---
+
+# My Skill
+
+## Overview
+
+Brief explanation.
+
+## Quick Reference
+
+Essential information here.
+
+## Advanced Topics
+
+Link to references if complex.
+```
+
+### Step 4: Test and Iterate
+
+1. Start a new Claude session
+2. Ask questions that should trigger the skill
+3. Verify Claude uses the skill appropriately
+4. Refine based on gaps
+
+## Creating a New Command
+
+### Step 1: Define the Workflow
+
+Commands are for explicit multi-step workflows:
+- What steps does this workflow include?
+- What tools are needed?
+- What output should the user see?
+
+### Step 2: Create the Command
+
+```bash
+touch .claude/commands/my-command.md
+```
+
+Write the command:
+
+```yaml
+---
+name: my-command
+description: 'Brief description for /help'
+argument-hint: '[--flag] [arg]'
+---
+
+# My Command
+
+## Instructions
+
+1. First step
+2. Second step
+3. Verify result
+
+## Handling Edge Cases
+
+What to do when X happens.
+```
+
+### Step 3: Test
+
+Run `/my-command` and verify the workflow executes correctly.
+
+## Common Patterns
+
+### Workflow with Verification
+
+```markdown
+## Workflow
+
+1. Gather context
+2. Perform action
+3. **Verify result before claiming success**
+4. Report outcome
+
+## Verification
+
+Always run `<command>` and check output before claiming complete.
+```
+
+### Reference Hub
+
+```markdown
+# API Reference Hub
+
+| API | Purpose | Reference |
+|-----|---------|-----------|
+| API A | Feature X | `references/api-a.md` |
+| API B | Feature Y | `references/api-b.md` |
+
+## When to Use Each
+
+Brief guidance on which reference to consult.
+```
+
+### Decision Matrix
+
+```markdown
+## Approach Selection
+
+| Condition | Approach |
+|-----------|----------|
+| Simple case | Do X |
+| Complex case | Do Y |
+| Edge case | Ask user |
+```
+
+## What NOT to Include
+
+- README.md, CHANGELOG.md (just clutter)
+- Obvious information Claude already knows
+- Overly detailed explanations (use examples instead)
+- User-facing documentation (skills are for Claude)
+
+## Skill vs Command Decision
+
+**Use a Skill when:**
+- Providing background knowledge
+- Teaching domain expertise
+- Reference material that applies across tasks
+
+**Use a Command when:**
+- Interactive workflow with user
+- Multi-step process needing explicit invocation
+- Specific task with defined start/end

--- a/.opencode/skills/systematic-debugging/SKILL.md
+++ b/.opencode/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,426 @@
+---
+name: systematic-debugging
+description: ALWAYS use before attempting any fix. Never jump to solutions - investigate root cause first. Use when encountering any technical issue, bug, test failure, or unexpected behavior.
+version: 2.0.0
+---
+
+# Systematic Debugging
+
+## Overview
+
+Random fixes waste time and create new bugs. Quick patches mask underlying
+issues.
+
+**Core principle:** ALWAYS find root cause before attempting fixes. Symptom
+fixes are failure.
+
+**Violating the letter of this process is violating the spirit of debugging.**
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose fixes.
+
+## When to Use
+
+Use for ANY technical issue:
+
+- Test failures
+- Bugs in production
+- Unexpected behavior
+- Performance problems
+- Build failures
+- Integration issues
+
+**Use this ESPECIALLY when:**
+
+- Under time pressure (emergencies make guessing tempting)
+- "Just one quick fix" seems obvious
+- You've already tried multiple fixes
+- Previous fix didn't work
+- You don't fully understand the issue
+
+**Don't skip when:**
+
+- Issue seems simple (simple bugs have root causes too)
+- You're in a hurry (rushing guarantees rework)
+- Manager wants it fixed NOW (systematic is faster than thrashing)
+
+## The Four Phases
+
+You MUST complete each phase before proceeding to the next.
+
+### Phase 1: Root Cause Investigation
+
+**BEFORE attempting ANY fix:**
+
+1. **Read Error Messages Carefully**
+   - Don't skip past errors or warnings
+   - They often contain the exact solution
+   - Read stack traces completely
+   - Note line numbers, file paths, error codes
+
+2. **Reproduce Consistently**
+   - Can you trigger it reliably?
+   - What are the exact steps?
+   - Does it happen every time?
+   - If not reproducible → gather more data, don't guess
+
+3. **Check Recent Changes**
+   - What changed that could cause this?
+   - Git diff, recent commits
+   - New dependencies, config changes
+   - Environmental differences
+
+4. **Gather Evidence in Multi-Component Systems**
+
+   **WHEN system has multiple components (CI → build → signing, API → service →
+   database):**
+
+   **BEFORE proposing fixes, add diagnostic instrumentation:**
+
+   ```
+   For EACH component boundary:
+     - Log what data enters component
+     - Log what data exits component
+     - Verify environment/config propagation
+     - Check state at each layer
+
+   Run once to gather evidence showing WHERE it breaks
+   THEN analyze evidence to identify failing component
+   THEN investigate that specific component
+   ```
+
+   **Example (multi-layer system):**
+
+   ```bash
+   # Layer 1: Workflow
+   echo "=== Secrets available in workflow: ==="
+   echo "IDENTITY: ${IDENTITY:+SET}${IDENTITY:-UNSET}"
+
+   # Layer 2: Build script
+   echo "=== Env vars in build script: ==="
+   env | grep IDENTITY || echo "IDENTITY not in environment"
+
+   # Layer 3: Signing script
+   echo "=== Keychain state: ==="
+   security list-keychains
+   security find-identity -v
+
+   # Layer 4: Actual signing
+   codesign --sign "$IDENTITY" --verbose=4 "$APP"
+   ```
+
+   **This reveals:** Which layer fails (secrets → workflow ✓, workflow → build ✗)
+
+5. **Trace Data Flow**
+
+   **WHEN error is deep in call stack:**
+
+   **Quick version:**
+   - Where does bad value originate?
+   - What called this with bad value?
+   - Keep tracing up until you find the source
+   - Fix at source, not at symptom
+
+### Phase 2: Pattern Analysis
+
+**Find the pattern before fixing:**
+
+1. **Find Working Examples**
+   - Locate similar working code in same codebase
+   - What works that's similar to what's broken?
+
+2. **Compare Against References**
+   - If implementing pattern, read reference implementation COMPLETELY
+   - Don't skim - read every line
+   - Understand the pattern fully before applying
+
+3. **Identify Differences**
+   - What's different between working and broken?
+   - List every difference, however small
+   - Don't assume "that can't matter"
+
+4. **Understand Dependencies**
+   - What other components does this need?
+   - What settings, config, environment?
+   - What assumptions does it make?
+
+### Phase 3: Hypothesis and Testing
+
+**Scientific method:**
+
+1. **Form Single Hypothesis**
+   - State clearly: "I think X is the root cause because Y"
+   - Write it down
+   - Be specific, not vague
+
+2. **Test Minimally**
+   - Make the SMALLEST possible change to test hypothesis
+   - One variable at a time
+   - Don't fix multiple things at once
+
+3. **Verify Before Continuing**
+   - Did it work? Yes → Phase 4
+   - Didn't work? Form NEW hypothesis
+   - DON'T add more fixes on top
+
+4. **When You Don't Know**
+   - Say "I don't understand X"
+   - Don't pretend to know
+   - Ask for help
+   - Research more
+
+### Phase 4: Implementation
+
+**Fix the root cause, not the symptom:**
+
+1. **Create Failing Test Case**
+   - Simplest possible reproduction
+   - Automated test if possible
+   - One-off test script if no framework
+   - MUST have before fixing
+
+2. **Implement Single Fix**
+   - Address the root cause identified
+   - ONE change at a time
+   - No "while I'm here" improvements
+   - No bundled refactoring
+
+3. **Verify Fix**
+   - Test passes now?
+   - No other tests broken?
+   - Issue actually resolved?
+
+4. **If Fix Doesn't Work**
+   - STOP
+   - Count: How many fixes have you tried?
+   - If < 3: Return to Phase 1, re-analyze with new information
+   - **If ≥ 3: STOP and question the architecture (step 5 below)**
+   - DON'T attempt Fix #4 without architectural discussion
+
+5. **If 3+ Fixes Failed: Question Architecture**
+
+   **Pattern indicating architectural problem:**
+   - Each fix reveals new shared state/coupling/problem in different place
+   - Fixes require "massive refactoring" to implement
+   - Each fix creates new symptoms elsewhere
+
+   **STOP and question fundamentals:**
+   - Is this pattern fundamentally sound?
+   - Are we "sticking with it through sheer inertia"?
+   - Should we refactor architecture vs. continue fixing symptoms?
+
+   **Discuss with the user before attempting more fixes**
+
+   This is NOT a failed hypothesis - this is a wrong architecture.
+
+## Red Flags - STOP and Follow Process
+
+If you catch yourself thinking:
+
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "Add multiple changes, run tests"
+- "Skip the test, I'll manually verify"
+- "It's probably X, let me fix that"
+- "I don't fully understand but this might work"
+- "Pattern says X but I'll adapt it differently"
+- "Here are the main problems: [lists fixes without investigation]"
+- Proposing solutions before tracing data flow
+- **"One more fix attempt" (when already tried 2+)**
+- **Each fix reveals new problem in different place**
+
+**ALL of these mean: STOP. Return to Phase 1.**
+
+**If 3+ fixes failed:** Question the architecture (see Phase 4.5)
+
+## Common Rationalizations
+
+| Excuse                                       | Reality                                                                 |
+| -------------------------------------------- | ----------------------------------------------------------------------- |
+| "Issue is simple, don't need process"        | Simple issues have root causes too. Process is fast for simple bugs.    |
+| "Emergency, no time for process"             | Systematic debugging is FASTER than guess-and-check thrashing.          |
+| "Just try this first, then investigate"      | First fix sets the pattern. Do it right from the start.                 |
+| "I'll write test after confirming fix works" | Untested fixes don't stick. Test first proves it.                       |
+| "Multiple fixes at once saves time"          | Can't isolate what worked. Causes new bugs.                             |
+| "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely.              |
+| "I see the problem, let me fix it"           | Seeing symptoms ≠ understanding root cause.                             |
+| "One more fix attempt" (after 2+ failures)   | 3+ failures = architectural problem. Question pattern, don't fix again. |
+
+## Quick Reference
+
+| Phase                 | Key Activities                                         | Success Criteria            |
+| --------------------- | ------------------------------------------------------ | --------------------------- |
+| **1. Root Cause**     | Read errors, reproduce, check changes, gather evidence | Understand WHAT and WHY     |
+| **2. Pattern**        | Find working examples, compare                         | Identify differences        |
+| **3. Hypothesis**     | Form theory, test minimally                            | Confirmed or new hypothesis |
+| **4. Implementation** | Create test, fix, verify                               | Bug resolved, tests pass    |
+
+## Technique: Root Cause Tracing
+
+When bugs manifest deep in the call stack, trace backward to find the original
+trigger.
+
+### The Tracing Process
+
+1. **Observe the Symptom**
+
+   ```
+   Error: git init failed in /Users/jesse/project/packages/core
+   ```
+
+2. **Find Immediate Cause** - What code directly causes this?
+
+   ```typescript
+   await execFileAsync('git', ['init'], { cwd: projectDir })
+   ```
+
+3. **Ask: What Called This?**
+
+   ```typescript
+   WorktreeManager.createSessionWorktree(projectDir, sessionId)
+     → called by Session.initializeWorkspace()
+     → called by Session.create()
+     → called by test at Project.create()
+   ```
+
+4. **Keep Tracing Up** - What value was passed?
+   - `projectDir = ''` (empty string!)
+   - Empty string as `cwd` resolves to `process.cwd()`
+
+5. **Find Original Trigger** - Where did empty string come from?
+   ```typescript
+   const context = setupCoreTest() // Returns { tempDir: '' }
+   Project.create('name', context.tempDir) // Accessed before beforeEach!
+   ```
+
+### Adding Stack Traces
+
+When you can't trace manually, add instrumentation:
+
+```typescript
+async function gitInit(directory: string) {
+  const stack = new Error().stack
+  console.error('DEBUG git init:', {
+    directory,
+    cwd: process.cwd(),
+    nodeEnv: process.env.NODE_ENV,
+    stack,
+  })
+  await execFileAsync('git', ['init'], { cwd: directory })
+}
+```
+
+**Tips:**
+
+- Use `console.error()` in tests (logger may be suppressed)
+- Log before the dangerous operation, not after it fails
+- Include context: directory, cwd, environment variables
+- `new Error().stack` shows complete call chain
+
+### Finding Which Test Causes Pollution
+
+If something appears during tests but you don't know which test, use bisection:
+
+```bash
+# Run tests one-by-one, stop at first polluter
+for f in src/**/*.test.ts; do
+  npm test "$f" && [ -d .git ] && echo "POLLUTER: $f" && break
+done
+```
+
+**NEVER fix just where the error appears.** Trace back to find the original
+trigger.
+
+## Technique: Defense-in-Depth Validation
+
+After finding root cause, validate at EVERY layer data passes through. Make the
+bug structurally impossible.
+
+### Why Multiple Layers
+
+- Single validation: "We fixed the bug"
+- Multiple layers: "We made the bug impossible"
+
+Different layers catch different cases:
+
+- Entry validation catches most bugs
+- Business logic catches edge cases
+- Environment guards prevent context-specific dangers
+- Debug logging helps when other layers fail
+
+### The Four Layers
+
+**Layer 1: Entry Point Validation** - Reject invalid input at API boundary
+
+```typescript
+function createProject(name: string, workingDirectory: string) {
+  if (!workingDirectory || workingDirectory.trim() === '') {
+    throw new Error('workingDirectory cannot be empty')
+  }
+  if (!existsSync(workingDirectory)) {
+    throw new Error(`workingDirectory does not exist: ${workingDirectory}`)
+  }
+}
+```
+
+**Layer 2: Business Logic Validation** - Ensure data makes sense for operation
+
+```typescript
+function initializeWorkspace(projectDir: string, sessionId: string) {
+  if (!projectDir) {
+    throw new Error('projectDir required for workspace initialization')
+  }
+}
+```
+
+**Layer 3: Environment Guards** - Prevent dangerous operations in specific
+contexts
+
+```typescript
+async function gitInit(directory: string) {
+  if (process.env.NODE_ENV === 'test') {
+    const normalized = normalize(resolve(directory))
+    const tmpDir = normalize(resolve(tmpdir()))
+    if (!normalized.startsWith(tmpDir)) {
+      throw new Error(`Refusing git init outside temp dir during tests`)
+    }
+  }
+}
+```
+
+**Layer 4: Debug Instrumentation** - Capture context for forensics
+
+```typescript
+async function gitInit(directory: string) {
+  logger.debug('About to git init', {
+    directory,
+    cwd: process.cwd(),
+    stack: new Error().stack,
+  })
+}
+```
+
+### Applying Defense-in-Depth
+
+When you find a bug:
+
+1. **Trace the data flow** - Where does bad value originate? Where used?
+2. **Map all checkpoints** - List every point data passes through
+3. **Add validation at each layer** - Entry, business, environment, debug
+4. **Test each layer** - Try to bypass layer 1, verify layer 2 catches it
+
+**Don't stop at one validation point.** Add checks at every layer.
+
+## Real-World Impact
+
+From debugging sessions:
+
+- Systematic approach: 15-30 minutes to fix
+- Random fixes approach: 2-3 hours of thrashing
+- First-time fix rate: 95% vs 40%
+- New bugs introduced: Near zero vs common

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Claudesidian: Claude Code + Obsidian Starter Kit
 
-Turn your Obsidian vault into an AI-powered second brain using Claude Code.
+Turn your Obsidian vault into an AI-powered second brain using Claude Code or OpenCode.
 
 ## What is this?
 
 This is a pre-configured Obsidian vault structure designed to work seamlessly
-with Claude Code, enabling you to:
+with Claude Code (or [OpenCode](https://github.com/sst/opencode), an open-source alternative), enabling you to:
 
 - Use AI as a thinking partner, not just a writing assistant
 - Organize knowledge using the PARA method
@@ -37,6 +37,8 @@ cd my-vault
 
 ### 2. Run the Setup Wizard
 
+**Using Claude Code:**
+
 ```bash
 # Start Claude Code in the directory
 claude
@@ -44,6 +46,18 @@ claude
 # Run the interactive setup wizard (in Claude Code)
 /init-bootstrap
 ```
+
+**Using OpenCode (open-source alternative):**
+
+```bash
+# Start OpenCode in the directory
+opencode
+
+# Run the interactive setup wizard
+/init-bootstrap
+```
+
+See [.opencode/README.md](.opencode/README.md) for OpenCode-specific setup details.
 
 This will:
 
@@ -67,7 +81,7 @@ This will:
 
 ### 4. Your First Session
 
-Tell Claude Code:
+Tell Claude Code (or OpenCode):
 
 ```
 I'm starting a new project about [topic].
@@ -76,7 +90,7 @@ Please search my vault for any relevant existing notes,
 then help me explore this topic by asking questions.
 ```
 
-Or use one of the pre-configured commands (in Claude Code):
+Or use one of the pre-configured commands:
 
 ```
 /thinking-partner   # For collaborative exploration
@@ -97,6 +111,8 @@ claudesidian/
 ├── 06_Metadata/        # Vault configuration and templates
 │   ├── Reference/      # Documentation and guides
 │   └── Templates/      # Reusable note templates
+├── .claude/            # Claude Code configuration
+├── .opencode/          # OpenCode configuration (alternative)
 └── .scripts/           # Helper scripts for automation
 ```
 
@@ -139,9 +155,9 @@ claudesidian/
 - Completed projects with their outputs
 - Old notes no longer relevant
 
-## Claude Code Commands
+## Commands
 
-Pre-configured AI assistants ready to use:
+Pre-configured AI assistants ready to use (works with both Claude Code and OpenCode):
 
 - `thinking-partner` - Explore ideas through questions
 - `inbox-processor` - Organize your captures
@@ -155,11 +171,11 @@ Pre-configured AI assistants ready to use:
 - `install-claudesidian-command` - Install shell command to launch vault from
   anywhere
 
-Run with: `/[command-name]` in Claude Code
+Run with: `/[command-name]`
 
 ### Staying Updated with `/upgrade`
 
-Claudesidian automatically checks for updates when you start Claude Code and
+Claudesidian automatically checks for updates when you start a session and
 will remind you to run `/upgrade` when new features are available.
 
 The upgrade command intelligently merges new features while preserving your
@@ -346,9 +362,9 @@ You are a research assistant.
 
 ## Troubleshooting
 
-### Claude Code can't find my notes
+### Can't find my notes
 
-- Make sure you're running Claude Code from the vault root directory
+- Make sure you're running from the vault root directory
 - Check file permissions
 - Verify markdown files have `.md` extension
 
@@ -391,13 +407,14 @@ better with everyone's input.
 
 ### What We're Looking For
 
-- **New commands**: Useful Claude Code commands for common workflows
+- **New commands**: Useful commands for common workflows
 - **New agents**: Specialized agents for specific tasks
 - **Documentation improvements**: Better explanations, examples, or guides
 - **Bug fixes**: Found something broken? Fix it!
 - **Workflow templates**: Share your productive workflows
 - **Helper scripts**: Automation tools that make vault management easier
 - **Integration guides**: Connect Claudesidian with other tools
+- **OpenCode compatibility**: Ensure features work with both Claude Code and OpenCode
 - **Core updates**: Improvements to the upgrade system, setup wizard, or other
   core features
 
@@ -437,6 +454,7 @@ makes this better for everyone!
 - [Obsidian Documentation](https://help.obsidian.md)
 - [PARA Method](https://fortelabs.com/blog/para/)
 - [Claude Code Documentation](https://claude.ai/docs)
+- [OpenCode GitHub](https://github.com/sst/opencode) - Open-source alternative
 
 ## Inspiration
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "license": "MIT",
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
-    "@modelcontextprotocol/sdk": "^1.25.2"
+    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@opencode-ai/plugin": "^1.1.19"
   },
   "devDependencies": {
     "@eslint/compat": "^1.4.1",


### PR DESCRIPTION
## Summary
Cf. #30 
Add support for [OpenCode](https://github.com/sst/opencode), an open-source alternative to Claude Code, allowing users to choose their preferred tool.

## Changes

- **New `.opencode/` directory** with full configuration:
  - `opencode.json` - Main config (permissions, MCP servers, instructions)
  - `command/` - All 15 commands ported to OpenCode format
  - `skills/` - All 6 skills copied
  - `plugin/session-hooks.ts` - TypeScript plugin for first-run welcome, update checking, and skill discovery

- **Updated files:**
  - `package.json` - Added `@opencode-ai/plugin` dependency
  - `README.md` - Added OpenCode as alternative setup path
  - `.claude/commands/init-bootstrap.md` - Added environment detection

## Key Design Decisions

1. **No model configuration in opencode.json** - Users configure their preferred LLM in their OpenCode setup, not per-project
2. **Same vault structure** - Both tools share the same PARA folders and CLAUDE.md
3. **Parallel configs** - `.claude/` for Claude Code, `.opencode/` for OpenCode - no conflicts

## Testing

- [x] All 15 commands ported and verified
- [x] All 6 skills copied
- [x] Plugin compiles with @opencode-ai/plugin types
- [x] README instructions work for both tools