### PR TITLE
fix: use portable shebangs

### DIFF
--- a/.claude/hooks/skill-discovery.sh
+++ b/.claude/hooks/skill-discovery.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Skill discovery hook - suggests relevant skills when user mentions "skill"
 # Exit 0 stdout → added as context for Claude
 # No dependencies - pure bash

--- a/.scripts/firecrawl-batch.sh
+++ b/.scripts/firecrawl-batch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Firecrawl batch scraper script
 # Usage: ./firecrawl-batch.sh [-o|--output-dir <dir>] <url1> <url2> ...

--- a/.scripts/firecrawl-scrape.sh
+++ b/.scripts/firecrawl-scrape.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Firecrawl scraper script that saves directly to file
 # Usage: ./firecrawl-scrape.sh <url> <output_file>

--- a/.scripts/transcript-extract.sh
+++ b/.scripts/transcript-extract.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Transcript extraction script for YouTube videos
 # Usage: .scripts/transcript-extract.sh <youtube-url> [output-path]

--- a/.scripts/vault-stats.sh
+++ b/.scripts/vault-stats.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Vault Statistics Script
 # Shows basic stats about your Obsidian vault

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Use portable Bash shebangs (`#!/usr/bin/env bash`) instead of hardcoded `/bin/bash` in project scripts
+
 ## [0.15.0] - 2026-04-10
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ Use these categories:
 - Use clear, descriptive variable names
 - Comment complex logic
 - Keep functions focused and small
+- For Bash scripts, use portable shebangs like `#!/usr/bin/env bash` instead of hardcoding `/bin/bash`
 - Test your changes thoroughly
 
 ## Questions?

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "🚀 Claudesidian Setup Script"
 echo "=========================="


### PR DESCRIPTION
**Problem**
On some systems (eg NixOS), bash is not in `/bin/bash` so running any of these bash scripts fail.

**Solution**
Use `#!/usr/bin/env bash` over `#!/bin/bash`.
Usage of `#!/usr/bin/env` is already prevelant in many of the skill scripts in this repo.