### PR TITLE
fix: make SessionStart hooks work on Windows

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,11 +5,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -f FIRST_RUN ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"\\n\\n# 🚀 Welcome to Claudesidian!\\n\\n**This appears to be your first time using this vault.**\\n\\n## Quick Start\\n\\nRun the setup wizard:\\n\\n⬇\\n/init-bootstrap\\n⬆\\n\\n## What this will do:\\n\\n✅ Set up your personalized configuration\\n✅ Disconnect from the original repository\\n✅ Help you import any existing Obsidian vault\\n✅ Configure your preferred workflow\\n✅ Create your PARA folder structure\\n\\nThe setup wizard will guide you through everything!\\n\\n\"}}' || true"
+            "command": "node .scripts/session-start.js"
           },
           {
             "type": "command",
-            "command": "npm run check-updates --silent 2>/dev/null || true"
+            "command": "npm run check-updates --silent"
           }
         ]
       }

--- a/.scripts/check-updates.js
+++ b/.scripts/check-updates.js
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const packageUrl =
+  'https://raw.githubusercontent.com/heyitsnoah/claudesidian/main/package.json'
+
+async function main() {
+  try {
+    const localPackage = JSON.parse(
+      await readFile(join(projectRoot, 'package.json'), 'utf8'),
+    )
+    const response = await fetch(packageUrl, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!response.ok) return
+
+    const remotePackage = await response.json()
+    if (
+      !remotePackage.version ||
+      remotePackage.version === localPackage.version
+    ) {
+      return
+    }
+
+    console.log(`📦 Update available! Latest: ${remotePackage.version} (you have: ${localPackage.version})
+
+⬇
+/upgrade
+⬆
+
+## What will this do
+
+✅ Update to the latest version of Claudesidian
+✅ Get new features and improvements
+✅ Preserve your vault content and settings
+`)
+  } catch {
+    // Update checks are advisory; startup should remain silent offline.
+  }
+}
+
+await main()

--- a/.scripts/session-start.js
+++ b/.scripts/session-start.js
@@ -1,0 +1,41 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
+
+if (existsSync(join(projectDir, 'FIRST_RUN'))) {
+  const additionalContext = `
+
+# 🚀 Welcome to Claudesidian!
+
+**This appears to be your first time using this vault.**
+
+## Quick Start
+
+Run the setup wizard:
+
+⬇
+/init-bootstrap
+⬆
+
+## What this will do:
+
+✅ Set up your personalized configuration
+✅ Disconnect from the original repository
+✅ Help you import any existing Obsidian vault
+✅ Configure your preferred workflow
+✅ Create your PARA folder structure
+
+The setup wizard will guide you through everything!
+
+`
+
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext,
+      },
+    }),
+  )
+}

--- a/.scripts/windows-session-hooks.test.js
+++ b/.scripts/windows-session-hooks.test.js
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const scriptsDir = import.meta.dirname;
+const sessionStart = join(scriptsDir, "session-start.js");
+
+function runSessionStart(projectDir) {
+  return execFileSync(process.execPath, [sessionStart], {
+    cwd: projectDir,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+    encoding: "utf8",
+  });
+}
+
+test("emits first-run context as valid hook JSON", () => {
+  const projectDir = mkdtempSync(join(tmpdir(), "claudesidian-hook-"));
+  try {
+    writeFileSync(join(projectDir, "FIRST_RUN"), "");
+
+    const payload = JSON.parse(runSessionStart(projectDir));
+
+    assert.equal(payload.hookSpecificOutput.hookEventName, "SessionStart");
+    assert.match(payload.hookSpecificOutput.additionalContext, /init-bootstrap/);
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test("stays silent after the vault has been initialized", () => {
+  const projectDir = mkdtempSync(join(tmpdir(), "claudesidian-hook-"));
+  try {
+    assert.equal(runSessionStart(projectDir), "");
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Run SessionStart hooks through cross-platform Node scripts instead of Bash-only
+  commands, so startup checks work on Windows as well as Unix-like systems. (#26)
+
 ## [0.15.1] - 2026-04-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "setup": "pnpm install && echo '✅ Setup complete! Configure GEMINI_API_KEY for vision features'",
+    "test": "node --test .scripts/windows-session-hooks.test.js",
     "test-gemini": "GEMINI_API_KEY=${GEMINI_API_KEY} node .claude/mcp-servers/gemini-vision.mjs",
     "lint": "eslint --config .config/eslint.config.js . --fix && prettier --config .config/.prettierrc.js --write .",
     "lint:check": "eslint --config .config/eslint.config.js . && prettier --config .config/.prettierrc.js --check .",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "transcript:extract": ".scripts/transcript-extract.sh",
     "vault:stats": ".scripts/vault-stats.sh",
     "skills:validate": "for d in .agents/skills/*/; do uv run --with pyyaml python .agents/skills/skill-creator/scripts/quick_validate.py \"$d\" || exit 1; done && echo '✅ All skills valid'",
-    "check-updates": "REMOTE=$(curl -s https://raw.githubusercontent.com/heyitsnoah/claudesidian/main/package.json | grep version | head -1 | sed 's/.*: \"\\(.*\\)\".*/\\1/') && LOCAL=$(grep version package.json | head -1 | sed 's/.*: \"\\(.*\\)\".*/\\1/') && if [ \"$LOCAL\" != \"$REMOTE\" ]; then echo -e \"📦 Update available! Latest: $REMOTE (you have: $LOCAL)\\n\\n⬇\\n/upgrade\\n⬆\\n\\n## What will this do\\n\\n✅ Update to the latest version of Claudesidian\\n✅ Get new features and improvements\\n✅ Preserve your vault content and settings\\n\\n\"; fi"
+    "check-updates": "node .scripts/check-updates.js"
   },
   "keywords": [
     "obsidian",


### PR DESCRIPTION
## Summary\n\nFixes #26 by replacing Bash-only SessionStart hook commands with Node entry points that run through the cross-platform Node runtime. The first-run hook preserves its JSON output, and the update check remains advisory and silent when the network is unavailable.\n\n## Validation\n\n- npm test\n- node --check .scripts/session-start.js\n- node --check .scripts/check-updates.js\n- settings JSON parse\n- git diff --check\n\nThis PR is ready for review.